### PR TITLE
jsonapi.rb switch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,10 +7,7 @@ gem 'rails', '~> 6.0.0'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 
-# gem 'blueprinter'
-# gem 'kaminari'
 gem 'jsonapi.rb'
-
 
 # gem 'redis', '~> 4.0'
 
@@ -20,8 +17,6 @@ gem 'rack-cors'
 group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails'
-  # gem 'rspec-json_expectations'
-  # gem 'jsonapi-matchers', github: 'PopularPays/jsonapi-matchers'
   gem 'jsonapi-rspec'
   gem 'factory_bot_rails'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,10 @@ gem 'rails', '~> 6.0.0'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 
-gem 'blueprinter'
-gem 'kaminari'
+# gem 'blueprinter'
+# gem 'kaminari'
+gem 'jsonapi.rb'
+
 
 # gem 'redis', '~> 4.0'
 
@@ -18,7 +20,9 @@ gem 'rack-cors'
 group :development, :test do
   gem 'pry-byebug'
   gem 'rspec-rails'
-  gem 'rspec-json_expectations'
+  # gem 'rspec-json_expectations'
+  # gem 'jsonapi-matchers', github: 'PopularPays/jsonapi-matchers'
+  gem 'jsonapi-rspec'
   gem 'factory_bot_rails'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -56,7 +56,6 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.1, >= 2.1.8)
-    blueprinter (0.19.0)
     bootsnap (1.4.5)
       msgpack (~> 1.0)
     builder (3.2.3)
@@ -73,24 +72,19 @@ GEM
     factory_bot_rails (5.1.1)
       factory_bot (~> 5.1.0)
       railties (>= 4.2.0)
+    fast_jsonapi (1.5)
+      activesupport (>= 4.2)
     ffi (1.11.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     json (2.2.0)
-    kaminari (1.1.1)
-      activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.1.1)
-      kaminari-activerecord (= 1.1.1)
-      kaminari-core (= 1.1.1)
-    kaminari-actionview (1.1.1)
-      actionview
-      kaminari-core (= 1.1.1)
-    kaminari-activerecord (1.1.1)
-      activerecord
-      kaminari-core (= 1.1.1)
-    kaminari-core (1.1.1)
+    jsonapi-rspec (0.0.2)
+    jsonapi.rb (1.5.3)
+      fast_jsonapi (~> 1.5)
+      rack
+      ransack
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -112,6 +106,8 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    polyamorous (2.3.0)
+      activerecord (>= 5.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -150,6 +146,12 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (13.0.0)
+    ransack (2.3.0)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
+      polyamorous (= 2.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -158,7 +160,6 @@ GEM
     rspec-expectations (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
-    rspec-json_expectations (2.2.0)
     rspec-mocks (3.9.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -181,7 +182,7 @@ GEM
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -195,24 +196,23 @@ GEM
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
-    zeitwerk (2.1.10)
+    zeitwerk (2.2.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  blueprinter
   bootsnap (>= 1.4.2)
   database_cleaner
   factory_bot_rails
-  kaminari
+  jsonapi-rspec
+  jsonapi.rb
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 3.11)
   rack-cors
   rails (~> 6.0.0)
-  rspec-json_expectations
   rspec-rails
   simplecov
   spring

--- a/app/blueprints/project_blueprint.rb
+++ b/app/blueprints/project_blueprint.rb
@@ -1,3 +1,0 @@
-class ProjectBlueprint < Blueprinter::Base
-  field :slug
-end

--- a/app/blueprints/transcription_blueprint.rb
+++ b/app/blueprints/transcription_blueprint.rb
@@ -1,3 +1,0 @@
-class TranscriptionBlueprint < Blueprinter::Base
-  fields :subject_id, :workflow_id, :group_id, :text, :status
-end

--- a/app/blueprints/workflow_blueprint.rb
+++ b/app/blueprints/workflow_blueprint.rb
@@ -1,3 +1,0 @@
-class WorkflowBlueprint < Blueprinter::Base
-  fields :project_id, :display_name
-end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :null_session
 
-  include Paginatable
+  # include Paginatable
 end

--- a/app/controllers/concerns/paginatable.rb
+++ b/app/controllers/concerns/paginatable.rb
@@ -1,7 +1,0 @@
-module Paginatable
-  extend ActiveSupport::Concern
-
-  def paginate(scope)
-    scope.page(page).per page_size
-  end
-end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,2 +1,20 @@
 class ProjectsController < ApplicationController
+  include JSONAPI::Pagination
+  include JSONAPI::Filtering
+
+  def index
+    @projects = Project.all
+    jsonapi_filter(@projects, allowed_filters) do |filtered|
+      jsonapi_paginate(filtered.result) do |paginated|
+        render jsonapi: paginated
+      end
+    end
+  end
+
+  private
+
+  def allowed_filters
+    [:slug]
+  end
+
 end

--- a/app/serializers/project_serializer.rb
+++ b/app/serializers/project_serializer.rb
@@ -1,0 +1,6 @@
+class ProjectSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :slug
+  has_many :workflows
+end

--- a/config/initializers/jsonapi.rb
+++ b/config/initializers/jsonapi.rb
@@ -1,0 +1,3 @@
+require 'jsonapi'
+
+JSONAPI::Rails.install!

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe ProjectsController, type: :controller do
         get :index, params: { filter: { slug_cont_any: "two" } }
         expect(response).to have_http_status(:ok)
         expect(json_data.size).to eq(1)
-        expect(json_data.first).to have_id(another_project.id.to_s)
+        expect(json_data.first).to have_id(another_project.id)
       end
     end
   end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe ProjectsController, type: :controller do
+
+  describe '#index' do
+    let!(:project) { create(:project, slug: "userone/projectone") }
+    let!(:another_project) { create(:project, slug: "usertwo/projecttwo") }
+
+    it "returns http success" do
+      get :index
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'should render' do
+      get :index
+      expect(json_data.first).to have_type('project')
+      expect(json_data.first).to have_attribute(:slug)
+      expect(json_data.first["id"]).to eql(project.id.to_s)
+    end
+
+    describe "pagination" do
+      it 'respects page size' do
+        get :index, params: { page: { size: 1 } }
+        expect(json_data.size).to eql(1)
+      end
+
+      it 'respects page number' do
+        get :index, params: { page: { number: 2, size: 1 } }
+        expect(json_data.first["id"]).to eql(another_project.id.to_s)
+      end
+    end
+
+    describe "filtration" do
+      it 'filters by slug' do
+        get :index, params: { filter: { slug_cont_any: "two" } }
+        expect(response).to have_http_status(:ok)
+        expect(json_data.size).to eq(1)
+        expect(json_data.first).to have_id(another_project.id.to_s)
+      end
+    end
+  end
+end

--- a/spec/factories/projects.rb
+++ b/spec/factories/projects.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :project do
-    slug { "username/project-name" }
+    sequence(:slug){ |n| "user_#{ n }/project_#{ n }" }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ require 'database_cleaner'
 RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
+  # config.include JSONAPI::RSpec
   config.filter_run :focus
   config.run_all_when_everything_filtered = true
   # rspec-expectations config goes here. You can use an alternate

--- a/spec/support/json_controller_helper.rb
+++ b/spec/support/json_controller_helper.rb
@@ -1,4 +1,7 @@
 def json_response
-  expect(response.body).not_to eq("")
-  JSON.parse(response.body)
+  JSON.parse(response.body).with_indifferent_access
+end
+
+def json_data
+  JSON.parse(response.body)["data"]
 end


### PR DESCRIPTION
First off, we're going all in on JSON:API, so g'bye Blueprinter.

Instead of the magical DSLs and empty controllers of JSONAPI::Resources or building filtration/pagination from scratch, I found a gem that pulls together a few of the gems I was considering using anyway (fast_jsonapi for serialization, Ransack for filtering) and does a few things I didn't wanna worry about (JSON:API pagination/meta links, error serializers, and RSpec matchers), all in like 500 LOC (nothing that couldn't be recreated manually).

It's tiny, but it's mostly stuff I'd have had to write anyway, so what the heck. Interested in any strongly held opinions about bundles like this.