### PR TITLE
Sync Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -216,8 +216,5 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
 
-RUBY VERSION
-   ruby 2.6.4p104
-
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
When the Ruby version was removed from the Gemfile, it also removed the specification from the Gemfile.lock. This wasn't represented till it was updated, so this PR syncs it up.