### PR TITLE
ensure the container is tagged with the git commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,6 +18,7 @@ pipeline {
 
           if (BRANCH_NAME == 'master') {
             stage('Update latest tag') {
+              newImage.push()
               newImage.push('latest')
             }
           }


### PR DESCRIPTION
k8 uses the git commit tag to find the correct container image to deploy, sure this is available in the image registry (docker hub).