### PR TITLE
Remove CSRF check from json requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,5 @@
 class ApplicationController < ActionController::Base
-  protect_from_forgery with: :null_session
+  protect_from_forgery unless: -> { request.format.json? }
 
   require 'authenticator'
   require 'panoptes_client'


### PR DESCRIPTION
Might want to revisit this at some point: I removed the forgery protection check completely and got a CSRF error when I tried to update a resource. Somehow, though, this works.