### PR TITLE
Strong params fix

### DIFF
--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -9,7 +9,7 @@ class TranscriptionsController < ApplicationController
   def update
     @transcription = Transcription.find(params[:id])
     raise ActionController::BadRequest if type_invalid?
-    @transcription.update(update_attrs)
+    @transcription.update!(update_attrs)
     render jsonapi: @transcription
   end
 
@@ -23,7 +23,7 @@ class TranscriptionsController < ApplicationController
   def update_attrs
     params.require(:data)
           .require(:attributes)
-          .permit(:text, :flagged, :status)
+          .permit(:flagged, :status, text: {})
   end
 
   def type_invalid?

--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -2,7 +2,6 @@ class Transcription < ApplicationRecord
   belongs_to :workflow
   belongs_to :subject
 
-  validates :text, presence: true
   validates :subject_id, presence: true
   validates :status, presence: true
   validates :group_id, presence: true

--- a/spec/models/transcription_spec.rb
+++ b/spec/models/transcription_spec.rb
@@ -15,5 +15,9 @@ RSpec.describe Transcription, type: :model do
     it 'requires text' do
       expect(build(:transcription, text: nil)).to_not be_valid
     end
+
+    it 'allows empty text' do
+      expect(create(:transcription, text: {})).to be_valid
+    end
   end
 end


### PR DESCRIPTION
* Strong params wasn't properly checking the data structure. It requires the jsonb field to be at the end for some reason.
* `validates :text, presence: true` uses `.blank?`, when in fact `text: {}` is valid JSON
* Use bang method when updating so it doesn't just return false and swallow the error