### PR TITLE
Allow filter by id

### DIFF
--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -31,6 +31,6 @@ class TranscriptionsController < ApplicationController
   end
 
   def allowed_filters
-    [:subject_id, :workflow_id, :group_id, :flagged]
+    [:id, :subject_id, :workflow_id, :group_id, :flagged]
   end
 end

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe TranscriptionsController, type: :controller do
 
       it 'respects page number' do
         get :index, params: { page: { number: 2, size: 1 } }
-        expect(json_data.first["id"]).to eql(another_transcription.id.to_s)
+        expect(json_data.first).to have_id(another_transcription.id.to_s)
       end
     end
 
@@ -47,6 +47,20 @@ RSpec.describe TranscriptionsController, type: :controller do
         get :index, params: { filter: { flagged_true: 1 } }
         expect(json_data.size).to eq(1)
         expect(json_data.first).to have_id(separate_transcription.id.to_s)
+      end
+
+      describe 'filters by id' do
+        it 'filters by single id' do
+          get :index, params: { filter: { id_eq: 1 } }
+          expect(json_data.size).to eq(1)
+          expect(json_data.first).to have_id(separate_transcription.id.to_s)
+        end
+
+        it 'filters by multiple ids' do
+          get :index, params: { filter: { flagged_true: 1 } }
+          expect(json_data.size).to eq(1)
+          expect(json_data.first).to have_id(separate_transcription.id.to_s)
+        end
       end
     end
   end

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -51,15 +51,14 @@ RSpec.describe TranscriptionsController, type: :controller do
 
       describe 'filters by id' do
         it 'filters by single id' do
-          get :index, params: { filter: { id_eq: 1 } }
+          get :index, params: { filter: { id_eq: transcription.id } }
           expect(json_data.size).to eq(1)
-          expect(json_data.first).to have_id(separate_transcription.id.to_s)
+          expect(json_data.first).to have_id(transcription.id.to_s)
         end
 
         it 'filters by multiple ids' do
-          get :index, params: { filter: { flagged_true: 1 } }
-          expect(json_data.size).to eq(1)
-          expect(json_data.first).to have_id(separate_transcription.id.to_s)
+          get :index, params: { filter: { id_in: "#{transcription.id},#{another_transcription.id}" } }
+          expect(json_data.size).to eq(2)
         end
       end
     end


### PR DESCRIPTION
Transcription ID should be filterable. This also allows the use of, say, `id_in=1,2` for querying for collections.