### PR TITLE
Add transcription group counts to Workflow serializer

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -1,6 +1,6 @@
 class WorkflowsController < ApplicationController
   def index
-    @workflows= Workflow.all
+    @workflows = Workflow.all
     jsonapi_render(@workflows, allowed_filters)
   end
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -4,4 +4,8 @@ class Workflow < ApplicationRecord
   has_many :transcriptions
 
   validates :display_name, presence: true
+
+  def groups
+    transcriptions.group(:group_id).count
+  end
 end

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -1,6 +1,6 @@
 class WorkflowSerializer
   include FastJsonapi::ObjectSerializer
 
-  attributes :display_name
+  attributes :display_name, :groups
   belongs_to :project
 end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -18,6 +18,12 @@ RSpec.describe WorkflowsController, type: :controller do
       expect(json_data.first["id"]).to eql(workflow.id.to_s)
     end
 
+    it 'serialized transcription groups' do
+      allow_any_instance_of(Workflow).to receive(:groups).and_return({"FIRST" => 2, "SECOND" => 1})
+      get :index
+      expect(json_data.first["attributes"]["groups"]).to eq({"FIRST" => 2, "SECOND" => 1})
+    end
+
     describe "pagination" do
       it 'respects page size' do
         get :index, params: { page: { size: 1 } }

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -4,4 +4,15 @@ RSpec.describe Workflow, type: :model do
       expect(build(:workflow, display_name: nil)).to_not be_valid
     end
   end
+
+  describe '#groups' do
+    let!(:workflow) { create(:workflow) }
+    let!(:transcription_one) { create(:transcription, workflow: workflow, group_id: "FIRST") }
+    let!(:transcription_two) { create(:transcription, workflow: workflow, group_id: "FIRST") }
+    let!(:transcription_three) { create(:transcription, workflow: workflow, group_id: "SECOND") }
+
+    it 'counts groups' do
+      expect(workflow.groups).to eq({"FIRST" => 2, "SECOND" => 1})
+    end
+  end
 end


### PR DESCRIPTION
First off: the purpose of this is to provide the data for this specific view: https://projects.invisionapp.com/share/JWSSI4KPMTX#/screens/378875744 (ignore the display name column).

That is, the "Group IDs found in a workflow". Group ID is an attribute of Transcriptions (by way of Panoptes subject metadata), and so it needs to be collated. 

To that end, this adds a `groups` attribute to serialized workflows. This is a uniqued list of all of the groups that are represented by that workflow's transcriptions, as well as their counts. (In the future, it may also include last-edit usernames and dates). This is kind of a query bummer, as a call to Workflows#index will generate extra count queries for each individual workflow. This is not a performance concern yet, and likely never will be as it is bounded by the number of workflows being actively processed and will usually be prefiltered by project anyway. 

That said, I also thought about creating and serializing a new `Group` model, but I couldn't think of a way to do that while keeping in spec without needing to duplicate data in a new Groups table. 

This should get @wgranger the data he needs to build the page while I'm gone, I can revisit this later if people have suggestions.

Sort of resolves https://github.com/zooniverse/tove/issues/33 