### PR TITLE
Abandon strong parameters

### DIFF
--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -4,10 +4,21 @@ module ErrorExtender
 
   included do
     rescue_from ActionController::BadRequest, with: :render_jsonapi_bad_request
+    rescue_from ActiveModel::UnknownAttributeError, with: :render_jsonapi_unknown_attribute
   end
 
   def render_jsonapi_bad_request(exception)
     error = { status: '400', title: Rack::Utils::HTTP_STATUS_CODES[400] }
     render jsonapi_errors: [error], status: :bad_request
+  end
+
+  def render_jsonapi_unknown_attribute(exception)
+    error = {
+      status: '422',
+      title: Rack::Utils::HTTP_STATUS_CODES[422],
+      detail: exception.to_param
+    }
+
+    render jsonapi_errors: [error], status: :unprocessable_entity
   end
 end

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -21,9 +21,7 @@ class TranscriptionsController < ApplicationController
   private
 
   def update_attrs
-    params.require(:data)
-          .require(:attributes)
-          .permit(:flagged, :status, text: {})
+    jsonapi_deserialize(params)
   end
 
   def type_invalid?

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -105,6 +105,12 @@ RSpec.describe TranscriptionsController, type: :controller do
         patch :update, params: busted_params
         expect(response).to have_http_status(:bad_request)
       end
+
+      it 'contains an invalid attribute' do
+        busted_params = { id: transcription.id, "data": { "type": "transcriptions", "attributes": { "garf": true } } }
+        patch :update, params: busted_params
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
     end
   end
 end


### PR DESCRIPTION
Attempting to use Rails' strong params for validation was a good place to start, but it's proving unwieldily. Otherwise totally valid requests with large json blobs in the `text` attribute were _mostly_ working, except deep in the json, the `clusters_text` object (an array of arrays, deeply nested) was being truncated to `[]` by something way way under the hood in `permit`. Last straw.

Instead, I'm using jsonapi.rb's `jsonapi_deserialize` method to parse the params. This yields a hash of the param's attributes, leaving you with `{}` if it's malformed. The resource is updated with a bang, so combining this with a proper catching of the UnknownAttribute method will work.