### PR TITLE
Add dev docs & optimize docker dev setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,42 @@ Or interactively / manually in a docker shell
 docker-compose run --rm -e RAILS_ENV=test app bash
 # from the bash prompt
 bin/rspec
+
+## Namesake
+
+>“You seem very clever at explaining words, Sir,” said Alice. “Would you kindly tell me the meaning of the poem ‘Jabberwocky’?”
+>\
+>\
+>“Let’s hear it,” said Humpty Dumpty. “I can explain all the poems that ever were invented—and a good many that haven’t been invented just yet.”
+>\
+>\
+This sounded very hopeful, so Alice repeated the first verse:
+>\
+>\
+‘Twas brillig, and the slithy toves
+Did gyre and gimble in the wabe:
+All mimsy were the borogoves,
+And the mome raths outgrabe.
+>\
+>\
+“That’s enough to begin with,” Humpty Dumpty interrupted: “there are plenty of hard words there. ‘Brillig’ means four o'clock in the afternoon—the time when you begin broiling things for dinner.”
+>\
+>\
+“That’ll do very well,” said Alice: “and ‘slithy’?”
+>\
+>\
+“Well, ‘slithy’ means ‘lithe and slimy.’ ‘Lithe’ is the same as ‘active.’ You see it’s like a portmanteau—there are two meanings packed up into one word.”
+>\
+>\
+“I see it now”, Alice remarked thoughtfully: “and what are ‘toves’?”
+>\
+>\
+“Well, ‘toves’ are something like badgers—they’re something like lizards—and they’re something like corkscrews.”
+>\
+>\
+“They must be very curious creatures.”
+>\
+>\
+“They are that,” said Humpty Dumpty: “also they make their nests under sun-dials—also they live on cheese.”
+
+--Lewis Carrol, "Through the Looking Glass"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TOVE: Transcription Object Viewer/Editor
 
-## Development
+*Readme and docs coming soon*	
 
 Prepare the Docker containers:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Or interactively / manually in a docker shell
 docker-compose run --rm -e RAILS_ENV=test app bash
 # from the bash prompt
 bin/rspec
+```
 
 ## Namesake
 

--- a/README.md
+++ b/README.md
@@ -1,40 +1,24 @@
 # TOVE: Transcription Object Viewer/Editor
 
-*Readme and docs coming soon*
+## Development
 
- >“You seem very clever at explaining words, Sir,” said Alice. “Would you kindly tell me the meaning of the poem ‘Jabberwocky’?”
->\
->\
->“Let’s hear it,” said Humpty Dumpty. “I can explain all the poems that ever were invented—and a good many that haven’t been invented just yet.”
->\
->\
-This sounded very hopeful, so Alice repeated the first verse:
->\
->\
-‘Twas brillig, and the slithy toves
-Did gyre and gimble in the wabe:
-All mimsy were the borogoves,
-And the mome raths outgrabe.
->\
->\
-“That’s enough to begin with,” Humpty Dumpty interrupted: “there are plenty of hard words there. ‘Brillig’ means four o'clock in the afternoon—the time when you begin broiling things for dinner.”
->\
->\
-“That’ll do very well,” said Alice: “and ‘slithy’?”
->\
->\
-“Well, ‘slithy’ means ‘lithe and slimy.’ ‘Lithe’ is the same as ‘active.’ You see it’s like a portmanteau—there are two meanings packed up into one word.”
->\
->\
-“I see it now”, Alice remarked thoughtfully: “and what are ‘toves’?”
->\
->\
-“Well, ‘toves’ are something like badgers—they’re something like lizards—and they’re something like corkscrews.”
->\
->\
-“They must be very curious creatures.”
->\
->\
-“They are that,” said Humpty Dumpty: “also they make their nests under sun-dials—also they live on cheese.”
+Prepare the Docker containers:
 
---Lewis Carrol, "Through the Looking Glass"
+```
+docker-compose build
+docker-compose run --rm app bundle exec rails db:setup
+docker-compose run --rm -e RAILS_ENV=test app bin/rails db:create
+```
+
+Run tests with:
+
+```
+docker-compose run --rm -e RAILS_ENV=test app bundle exec rspec
+```
+
+Or interactively / manually in a docker shell
+
+```
+docker-compose run --rm -e RAILS_ENV=test app bash
+# from the bash prompt
+bin/rspec

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: '2'
+version: '3'
 services:
   postgres:
-    image: postgres:9.4
+    image: postgres:9.5
     environment:
       - "POSTGRES_USER=tove"
       - "POSTGRES_PASSWORD=tove"
@@ -9,10 +9,12 @@ services:
   app:
     build:
       context: .
+      dockerfile: Dockerfile
       args:
         RAILS_ENV: development
     volumes:
       - ./:/app
+      - gem_cache:/usr/local/bundle
     ports:
       - "3000:80"
     environment:
@@ -21,3 +23,6 @@ services:
       - "DATABASE_URL_TEST=postgresql://tove:tove@postgres/tove_test"
     links:
       - postgres:postgres
+
+volumes:
+  gem_cache:


### PR DESCRIPTION
add docs and allow the docker images gems to be reused in development. This will populate the gem_cache data volume with the image gems and allow you to modify & persist them from the container, e.g. change `Gemfile` entry and `bundle install` will have the new gems persisted across container boots. 