### PR TITLE
Override gem rescue_from on StandardError to report to Sentry

### DIFF
--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -12,8 +12,7 @@ module ErrorExtender
       Raven.user_context(
         id: current_user.id,
         username: current_user.login,
-        roles: current_user.roles,
-
+        roles: current_user.roles
       )
     end
     Raven.capture_exception(exception)

--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -5,6 +5,21 @@ module ErrorExtender
   included do
     rescue_from ActionController::BadRequest, with: :render_jsonapi_bad_request
     rescue_from ActiveModel::UnknownAttributeError, with: :render_jsonapi_unknown_attribute
+    rescue_from StandardError, with: :report_to_sentry
+  end
+
+  def report_to_sentry(exception)
+    if current_user
+      Raven.user_context(
+        id: current_user.id,
+        username: current_user.login,
+        roles: current_user.roles,
+
+      )
+    end
+
+    Raven.capture_exception(exception)
+    render_jsonapi_internal_server_error(exception)
   end
 
   def render_jsonapi_bad_request(exception)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -41,7 +41,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :info
+  config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   config.log_tags = [ :request_id ]

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,4 +1,5 @@
 RSpec.describe ApplicationController, type: :controller do
+  let(:user){ create :user }
 
   describe 'error handling' do
     controller do
@@ -8,6 +9,7 @@ RSpec.describe ApplicationController, type: :controller do
     end
 
     it 'sends StandardErrors to Sentry' do
+      allow(controller).to receive(:current_user).and_return user
       expect(controller).to receive(:report_to_sentry).and_call_original
       get :index
       expect(response).to have_http_status(500)

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,5 +1,19 @@
 RSpec.describe ApplicationController, type: :controller do
 
+  describe 'error handling' do
+    controller do
+      def index
+        raise StandardError
+      end
+    end
+
+    it 'sends StandardErrors to Sentry' do
+      expect(controller).to receive(:report_to_sentry).and_call_original
+      get :index
+      expect(response).to have_http_status(500)
+    end
+  end
+
   describe '#auth_token' do
     let(:token){ nil }
 

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe ApplicationController, type: :controller do
     it 'sends StandardErrors to Sentry' do
       allow(controller).to receive(:current_user).and_return user
       expect(controller).to receive(:report_to_sentry).and_call_original
+      expect(Raven).to receive(:capture_exception)
       get :index
       expect(response).to have_http_status(500)
     end


### PR DESCRIPTION
The JSON:API gem I'm using includes functionality to rescue_from and serialize errors. This includes StandardError, which serializes a 500. I want to catch those first and send them to Sentry before they're serialized. 

I'm hoping that this rescue_from in my ErrorExtender will override the one here:
https://github.com/stas/jsonapi.rb/blob/5a593edcbfac1b48242c5104cd904a138793834d/lib/jsonapi/errors.rb#L13

I just want to contextualize and report the error before passing the exception on to the renderer. Hopefully this will mean that we start seeing these 500s (and their stack traces) in Sentry.

I also changed the log level on staging to `:debug` so hopefully that'll add some stack traces to the logs.