### PR TITLE
patch for the workflow transcription groups data collation method

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -11,28 +11,47 @@ class Workflow < ApplicationRecord
   #   * transcription count
   #   * last updated at
   #   * last updated by
-  def groups
-    transcription_counts = transcriptions.group(:group_id).count(:id)
-    # get most recent updated_at date for each group, use .where to join onto transcription table
-    groups_last_updated_at = transcriptions.group(:group_id)
-                                           .maximum(:updated_at)
-                                           .map { |_group, date| date } # get only the date
-    groups_data = transcriptions.where(updated_at: groups_last_updated_at)
-                                .map do |g|
-                                  [g['group_id'],
-                                  {
-                                    updated_at: g['updated_at'],
-                                    updated_by: g['updated_by']
-                                  }]
-                                end.to_h
-    
-    # add group count to groups_data object
-    groups_data.each do |key, value|
-      value[:transcription_count] = transcription_counts[key]
+  def transcription_group_data
+    transcription_group_data = {}
+    group_transcriptions = ordered_transcription_groups.group_by { |group| group.group_id }
+    group_transcriptions.each do |group_id, data|
+      # take the first/latest update_at transcription
+      transcription = data.first
+      # get the count from the number of transcriptions in the group
+      # Note: this may be sub-optimal if a group can have a large number transcriptions
+      # as we only use the data in the first record and count the rest only.
+      group_transcription_count = data.count
+
+      # construct the resulting data record results
+      #
+      # IMHO these look a lot like a data record that could easily be stored in the database
+      # and we're getting into another association territory with this method
+      # especially as the workflow is really leaning on the transcription assocation here,
+      # it's not really anything to do with a workflow but it's serialized as a workflow attribute...
+      transcription_group_data[group_id] =
+        {
+          updated_at: transcription.max_date,
+          updated_by: transcription.updated_by,
+          transcription_count: group_transcription_count
+        }
     end
+
+    transcription_group_data
   end
 
   def total_transcriptions
     transcriptions.count
+  end
+
+  private
+
+  # fetch the grouped workflow transcriptions
+  # along with the groups latest transcription updated_at
+  # we also sort the group transcriptions so the first record is the latest transcription
+  def ordered_transcription_groups
+    transcriptions
+      .select( "group_id, updated_by, max(updated_at) as max_date")
+      .group(:group_id, :updated_by)
+      .order("max_date DESC, group_id")
   end
 end

--- a/app/serializers/workflow_serializer.rb
+++ b/app/serializers/workflow_serializer.rb
@@ -1,6 +1,7 @@
 class WorkflowSerializer
   include FastJsonapi::ObjectSerializer
 
-  attributes :display_name, :groups, :total_transcriptions
+  attributes :display_name, :total_transcriptions
+  attribute :groups, &:transcription_group_data
   belongs_to :project
 end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe WorkflowsController, type: :controller do
     end
 
     it 'serialized transcription groups' do
-      allow_any_instance_of(Workflow).to receive(:groups).and_return({"FIRST" => 2, "SECOND" => 1})
+      # TODO: the results here look out of sync with the actual group data from the workflow
+      # that shoudl be fixed or tested elsewhere.... maybe on the serializer itself?
+      allow_any_instance_of(Workflow).to receive(:transcription_group_data).and_return({"FIRST" => 2, "SECOND" => 1})
       get :index
       expect(json_data.first["attributes"]["groups"]).to eq({"FIRST" => 2, "SECOND" => 1})
     end

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -24,9 +24,30 @@ RSpec.describe WorkflowsController, type: :controller do
     it 'serialized transcription groups' do
       # TODO: the results here look out of sync with the actual group data from the workflow
       # that shoudl be fixed or tested elsewhere.... maybe on the serializer itself?
-      allow_any_instance_of(Workflow).to receive(:transcription_group_data).and_return({"FIRST" => 2, "SECOND" => 1})
+      allow_any_instance_of(Workflow).to receive(:transcription_group_data)
+                                         .and_return({
+                                            'FIRST' => {
+                                              "updated_at": '2019-12-16 00:00:00 UTC',
+                                              "updated_by": 'The Dark Master',
+                                              "transcription_count": 1
+                                            },
+                                            "SECOND" => {
+                                              "updated_at": '2019-12-18 00:00:00 UTC',
+                                              "updated_by": 'The Grey Tiger',
+                                              "transcription_count": 2
+                                            }})
       get :index
-      expect(json_data.first["attributes"]["groups"]).to eq({"FIRST" => 2, "SECOND" => 1})
+      expect(json_data.first["attributes"]["groups"]).to eq(
+        {"FIRST" => {
+          "updated_at" => '2019-12-16 00:00:00 UTC',
+          "updated_by" => 'The Dark Master',
+          "transcription_count" => 1
+        }, 
+        "SECOND" => {
+          "updated_at" => '2019-12-18 00:00:00 UTC',
+          "updated_by" => 'The Grey Tiger',
+          "transcription_count" => 2
+        }})
     end
 
     describe "filtration" do

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -30,15 +30,15 @@ RSpec.describe Workflow, type: :model do
            updated_by: 'Dove')
   end
 
-  describe '#groups' do
+  describe '#transcription_group_data' do
     it 'counts transcriptions per group' do
-      expect(workflow.groups['FIRST'][:transcription_count]).to eq(2)
+      expect(workflow.transcription_group_data['FIRST'][:transcription_count]).to eq(2)
     end
     it 'gets the date of the most recently updated transcription' do
-      expect(workflow.groups['FIRST'][:updated_at]).to eq('2019-12-16 00:00:00 UTC')
+      expect(workflow.transcription_group_data['FIRST'][:updated_at]).to eq('2019-12-16 00:00:00 UTC')
     end
     it 'gets the user who last updated a transcription of the group' do
-      expect(workflow.groups['FIRST'][:updated_by]).to eq('Ursula')
+      expect(workflow.transcription_group_data['FIRST'][:updated_by]).to eq('Ursula')
     end
   end
 


### PR DESCRIPTION
Here is a refactor attempt to use 1 group by query and try to make the code clearer about what we're trying to do here. 

As i say in the comments, i think this kind of query on the workflow record is really trying to tell us that we are missing an pre-computed attribute on workflow or a view / table in the database that records this information as it's collated. 

The fact that a workflow relies on the transcription association grouping queries so heavily when serializing the workflow state is a sign we should be looking to extract this to it's own table or storing this information on the workflow via json, etc. 

Also I ran an explain on the updated group query on test data (test data may not represent the real query plan on more realistic data loads). However when looking into this i couldn't see any FK indexes on tables so these queries will always be table scans which will slow down once data starts filing in. 

#### transcription group data query explain
```
[1] pry(#<Workflow>)> ordered_transcription_groups.explain
=> EXPLAIN for: SELECT group_id, updated_by, max(updated_at) as max_date FROM "transcriptions" WHERE "transcriptions"."workflow_id" = $1 GROUP BY "transcriptions"."group_id", "transcriptions"."updated_by" ORDER BY max_date DESC, group_id [["workflow_id", 295]]
                                QUERY PLAN
---------------------------------------------------------------------------
 Sort  (cost=1.06..1.07 rows=1 width=72)
   Sort Key: (max(updated_at)) DESC, group_id
   ->  HashAggregate  (cost=1.04..1.05 rows=1 width=72)
         Group Key: group_id, updated_by
         ->  Seq Scan on transcriptions  (cost=0.00..1.04 rows=1 width=72)
               Filter: (workflow_id = 295)
(6 rows)
```
#### psql table info looking for indexes on FKs
```
tove_test=# \d workflows
                                        Table "public.workflows"
    Column    |              Type              |                       Modifiers                        
--------------+--------------------------------+--------------------------------------------------------
 id           | bigint                         | not null default nextval('workflows_id_seq'::regclass)
 project_id   | integer                        | not null
 display_name | character varying              | not null
 created_at   | timestamp(6) without time zone | not null
 updated_at   | timestamp(6) without time zone | not null
Indexes:
    "workflows_pkey" PRIMARY KEY, btree (id)

tove_test=# \d transcriptions
                                       Table "public.transcriptions"
   Column    |              Type              |                          Modifiers                          
-------------+--------------------------------+-------------------------------------------------------------
 id          | bigint                         | not null default nextval('transcriptions_id_seq'::regclass)
 subject_id  | integer                        | not null
 workflow_id | integer                        | not null
 group_id    | character varying              | not null
 text        | jsonb                          | not null
 status      | integer                        | not null
 flagged     | boolean                        | not null default false
 created_at  | timestamp(6) without time zone | not null
 updated_at  | timestamp(6) without time zone | not null
 updated_by  | character varying              | 
 total_lines | integer                        | 
 total_pages | integer                        | 
Indexes:
    "transcriptions_pkey" PRIMARY KEY, btree (id)
```