### PR TITLE
Filter by status word

### DIFF
--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -32,8 +32,16 @@ class TranscriptionsController < ApplicationController
     if params[:filter]
       params[:filter].each do |key, value|
         if key.split('_').first == 'status'
-          enum_value = Transcription.statuses[value]
-          params[:filter][key] = enum_value if enum_value
+          status_terms = value.split(',')
+          status_enum_values = []
+          status_terms.each do |term|
+            enum_value = Transcription.statuses[term]
+            status_enum_values.append(enum_value.to_s) if enum_value
+          end
+          
+          unless status_enum_values.empty?
+            params[:filter][key] = status_enum_values.join(',')
+          end
         end
       end
     end

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -1,6 +1,8 @@
 class TranscriptionsController < ApplicationController
   include JSONAPI::Deserialization
 
+  before_action :status_filter_to_int, only: :index
+
   def index
     @transcriptions = Transcription.all
     jsonapi_render(@transcriptions, allowed_filters)
@@ -22,6 +24,19 @@ class TranscriptionsController < ApplicationController
 
   def update_attrs
     jsonapi_deserialize(params)
+  end
+
+  # jsonapi.rb filtering doesn't handle filtering by enum term (e.g. 'ready'),
+  # so we must translate status terms to their integer value if they're present
+  def status_filter_to_int
+    if params[:filter]
+      params[:filter].each do |key, value|
+        if key.split('_').first == 'status'
+          enum_value = Transcription.statuses[value]
+          params[:filter][key] = enum_value if enum_value
+        end
+      end
+    end
   end
 
   def type_invalid?

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -32,13 +32,19 @@ class TranscriptionsController < ApplicationController
     if params[:filter]
       params[:filter].each do |key, value|
         if key.split('_').first == 'status'
+          # split status terms in case there is a list of them
           status_terms = value.split(',')
           status_enum_values = []
+          
+          # for each status term, try to convert to enum value,
+          # and add to list of converted enum values
           status_terms.each do |term|
             enum_value = Transcription.statuses[term]
             status_enum_values.append(enum_value.to_s) if enum_value
           end
           
+          # if list of converted enum values is not empty,
+          # update params to reflect converted values
           unless status_enum_values.empty?
             params[:filter][key] = status_enum_values.join(',')
           end

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -31,6 +31,8 @@ class TranscriptionsController < ApplicationController
   def status_filter_to_int
     if params[:filter]
       params[:filter].each do |key, value|
+        # filter key is comprised of <filterterm>_<relationship> 
+        # e.g. id_eq, status_in, etc - check if filter term is status
         if key.split('_').first == 'status'
           # split status terms in case there is a list of them
           status_terms = value.split(',')

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -54,14 +54,26 @@ RSpec.describe TranscriptionsController, type: :controller do
       end
 
       describe 'filters by status' do
-        it 'filters by single status' do
+        it 'filters by single status id' do
           get :index, params: { filter: { status_eq: another_transcription.status_before_type_cast } }
           expect(json_data.size).to eq(1)
           expect(json_data.first["attributes"]["status"]).to eq(another_transcription.status)
         end
 
-        it 'filters by multiple statuses' do
+        it 'filters by multiple status ids' do
           status_filter = "#{another_transcription.status_before_type_cast},#{separate_transcription.status_before_type_cast}"
+          get :index, params: { filter: { status_in: status_filter } }
+          expect(json_data.size).to eq(2)
+        end
+
+        it 'filters by status term' do
+          get :index, params: { filter: { status_eq: another_transcription.status }}
+          expect(json_data.size).to eq(1)
+          expect(json_data.first["attributes"]["status"]).to eq(another_transcription.status)
+        end
+
+        it 'filters by multiple status terms' do
+          status_filter = "#{another_transcription.status},#{separate_transcription.status}"
           get :index, params: { filter: { status_in: status_filter } }
           expect(json_data.size).to eq(2)
         end


### PR DESCRIPTION
Resolves issue #73.

When a request comes in, check the query params to see if we are filtering by status. If so, check if the request is trying to filter by status word. If so, convert to an integer.

This will handle cases of filtering by a single status word AND filtering by a list of status words.