### PR TITLE
Turn off deep munging

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -35,5 +35,6 @@ module Tove
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.action_dispatch.perform_deep_munge = false
   end
 end


### PR DESCRIPTION
Turn off deep munging so Rails stops stripping nulls out of JSON payloads. See https://github.com/rails/rails/issues/13420 for details. 