### PR TITLE
Change Status Enum Order

### DIFF
--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -6,10 +6,10 @@ class Transcription < ApplicationRecord
   validate :text_json_is_not_nil
 
   enum status: {
-    unseen: 0,
-    ready: 1, # ready as in "ready for approval"
-    in_progress: 2,
-    approved: 3
+    approved: 0,
+    in_progress: 1,
+    ready: 2, # ready as in "ready for approval"
+    unseen: 3
 
   }
 

--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -8,8 +8,8 @@ class Transcription < ApplicationRecord
   enum status: {
     unseen: 0,
     ready: 1, # ready as in "ready for approval"
-    approved: 2,
-    in_progress: 3
+    in_progress: 2,
+    approved: 3
 
   }
 


### PR DESCRIPTION
Not much going on here, simply changing the enum order so items appear in alphabetical order when I make a call to sort transcriptions from the frontend. More info in the attached issue. 

Closes #120 