### PR TITLE
Check for Valid Data When Updating

### DIFF
--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -4,7 +4,6 @@ module ErrorExtender
 
   included do
     rescue_from ActionController::BadRequest, with: :render_jsonapi_bad_request
-    rescue_from ActiveModel::UnknownAttributeError, with: :render_jsonapi_unknown_attribute
     rescue_from Panoptes::Client::AuthenticationExpired, with: :render_jsonapi_token_expired
     rescue_from Pundit::NotAuthorizedError, with: :render_jsonapi_not_authorized
     rescue_from ActionDispatch::Http::Parameters::ParseError, with: :render_jsonapi_bad_request
@@ -35,16 +34,6 @@ module ErrorExtender
   def render_jsonapi_token_expired(exception)
     error = { status: '401', title: Rack::Utils::HTTP_STATUS_CODES[401] }
     render jsonapi_errors: [error], status: :unauthorized
-  end
-
-  def render_jsonapi_unknown_attribute(exception)
-    error = {
-      status: '422',
-      title: Rack::Utils::HTTP_STATUS_CODES[422],
-      detail: exception.to_param
-    }
-
-    render jsonapi_errors: [error], status: :unprocessable_entity
   end
 
   def render_jsonapi_not_authorized

--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -7,6 +7,7 @@ module ErrorExtender
     rescue_from ActiveModel::UnknownAttributeError, with: :render_jsonapi_unknown_attribute
     rescue_from Panoptes::Client::AuthenticationExpired, with: :render_jsonapi_token_expired
     rescue_from Pundit::NotAuthorizedError, with: :render_jsonapi_not_authorized
+    rescue_from ActionDispatch::Http::Parameters::ParseError, with: :render_jsonapi_bad_request
   end
 
   def report_to_sentry(exception)

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -17,7 +17,7 @@ class TranscriptionsController < ApplicationController
   def update
     @transcription = Transcription.find(params[:id])
     raise ActionController::BadRequest if type_invalid?
-    raise Pundit::NotAuthorizedError unless whitelisted_attributes?
+    raise ActionController::BadRequest unless whitelisted_attributes?
 
     if approve?
       authorize @transcription, :approve?
@@ -69,7 +69,7 @@ class TranscriptionsController < ApplicationController
   end
 
   def whitelisted_attributes?
-    params[:data][:attributes] && params[:data][:attributes].keys.all? { |key| update_attr_whitelist.include? key }
+    update_attrs.keys.all? { |key| update_attr_whitelist.include? key }
   end
 
   def approve?

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -69,7 +69,7 @@ class TranscriptionsController < ApplicationController
   end
 
   def whitelisted_attributes?
-    params[:data][:attributes] && params[:data][:attributes].keys.all? { |key| whitelist.include? key }
+    params[:data][:attributes] && params[:data][:attributes].keys.all? { |key| update_attr_whitelist.include? key }
   end
 
   def approve?
@@ -80,7 +80,7 @@ class TranscriptionsController < ApplicationController
     [:id, :workflow_id, :group_id, :flagged, :status]
   end
 
-  def whitelist
+  def update_attr_whitelist
     ["flagged", "text", "status"]
   end
 end

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -16,7 +16,7 @@ class TranscriptionsController < ApplicationController
 
   def update
     @transcription = Transcription.find(params[:id])
-    raise ActionController::BadRequest if invalid_type?
+    raise ActionController::BadRequest if type_invalid?
     raise Pundit::NotAuthorizedError unless whitelisted_attributes?
 
     if approve?
@@ -64,7 +64,7 @@ class TranscriptionsController < ApplicationController
     end
   end
 
-  def invalid_type?
+  def type_invalid?
     params[:data][:type] != "transcriptions"
   end
 

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -31,6 +31,7 @@ class TranscriptionsController < ApplicationController
   private
 
   def update_attrs
+    params[:data][:attributes].delete_if { |k| whitelisted_attributes.exclude? k }
     jsonapi_deserialize(params)
   end
 
@@ -73,5 +74,9 @@ class TranscriptionsController < ApplicationController
 
   def allowed_filters
     [:id, :workflow_id, :group_id, :flagged, :status]
+  end
+
+  def whitelisted_attributes
+    ["flagged", "text", "status"]
   end
 end

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -31,7 +31,9 @@ class TranscriptionsController < ApplicationController
   private
 
   def update_attrs
-    params[:data][:attributes].delete_if { |k| whitelisted_attributes.exclude? k }
+    if params[:data] && params[:data][:attributes]
+      params[:data][:attributes].delete_if { |k| whitelisted_attributes.exclude? k }
+    end
     jsonapi_deserialize(params)
   end
 

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -170,13 +170,13 @@ RSpec.describe TranscriptionsController, type: :controller do
       it 'contains an invalid attribute' do
         busted_params = { id: transcription.id, "data": { "type": "transcriptions", "attributes": { "garf": true } } }
         patch :update, params: busted_params
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:bad_request)
       end
 
       it 'contains read-only data' do
         busted_params = { id: transcription.id, "data": { "type": "transcriptions", "attributes": { "group_id": "fake_id" } } }
         patch :update, params: busted_params
-        expect(response).to have_http_status(:forbidden)
+        expect(response).to have_http_status(:bad_request)
       end
     end
 

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -167,10 +167,10 @@ RSpec.describe TranscriptionsController, type: :controller do
         expect(response).to have_http_status(:bad_request)
       end
 
-      it 'contains an invalid attribute' do
-        busted_params = { id: transcription.id, "data": { "type": "transcriptions", "attributes": { "garf": true } } }
+      it 'contains invalid data' do
+        busted_params = { id: transcription.id, "data": { "type": "transcriptions", "pet": "dog" } }
         patch :update, params: busted_params
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(json_data).not_to have_key("pet")
       end
 
       it 'will only update whitelisted attributes' do

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -172,6 +172,14 @@ RSpec.describe TranscriptionsController, type: :controller do
         patch :update, params: busted_params
         expect(response).to have_http_status(:unprocessable_entity)
       end
+
+      it 'will only update whitelisted attributes' do
+        busted_params = { id: transcription.id, "data": { "type": "transcriptions", "attributes": { "group_id": "fake_group", "flagged": true } } }
+        patch :update, params: busted_params
+        expect(json_data["attributes"]["flagged"]).to be true
+        expect(json_data["attributes"]["group_id"]).not_to be('fake_group')
+        expect(json_data["attributes"]["workflow_id"]).not_to be(1000)
+      end
     end
 
     describe 'roles' do

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -167,18 +167,16 @@ RSpec.describe TranscriptionsController, type: :controller do
         expect(response).to have_http_status(:bad_request)
       end
 
-      it 'contains invalid data' do
-        busted_params = { id: transcription.id, "data": { "type": "transcriptions", "pet": "dog" } }
+      it 'contains an invalid attribute' do
+        busted_params = { id: transcription.id, "data": { "type": "transcriptions", "attributes": { "garf": true } } }
         patch :update, params: busted_params
-        expect(json_data).not_to have_key("pet")
+        expect(response).to have_http_status(:forbidden)
       end
 
-      it 'will only update whitelisted attributes' do
-        busted_params = { id: transcription.id, "data": { "type": "transcriptions", "attributes": { "group_id": "fake_group", "flagged": true } } }
+      it 'contains read-only data' do
+        busted_params = { id: transcription.id, "data": { "type": "transcriptions", "attributes": { "group_id": "fake_id" } } }
         patch :update, params: busted_params
-        expect(json_data["attributes"]["flagged"]).to be true
-        expect(json_data["attributes"]["group_id"]).not_to be('fake_group')
-        expect(json_data["attributes"]["workflow_id"]).not_to be(1000)
+        expect(response).to have_http_status(:forbidden)
       end
     end
 


### PR DESCRIPTION
This PR checks for valid data when sending a PATCH and makes sure you can only update whitelisted data. It _should_ also close #92 but mainly by sending a `400` instead of failing miserably when getting data it can't parse. Rails has a tendency of failing before even getting to the update method when this occurs, so handling it a bit more elegantly might be the best option.

I also added a whitelist to the attributes that are updated. This will keep people from updating stuff like the `group_id`, which we really don't want people altering. 

I altered a test a bit because the original test would respond with a `200` since the improper attributes would be stripped.