### PR TITLE
Reverse Enum Order

### DIFF
--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -6,10 +6,10 @@ class Transcription < ApplicationRecord
   validate :text_json_is_not_nil
 
   enum status: {
-    unseen: 0,
-    ready: 1, # ready as in "ready for approval"
-    in_progress: 2,
-    approved: 3
+    approved: 0,
+    in_progress: 1,
+    ready: 2, # ready as in "ready for approval"
+    unseen: 3
 
   }
 

--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -6,10 +6,10 @@ class Transcription < ApplicationRecord
   validate :text_json_is_not_nil
 
   enum status: {
-    approved: 0,
-    in_progress: 1,
-    ready: 2, # ready as in "ready for approval"
-    unseen: 3
+    unseen: 0,
+    ready: 1, # ready as in "ready for approval"
+    in_progress: 2,
+    approved: 3
 
   }
 

--- a/app/services/caesar_importer.rb
+++ b/app/services/caesar_importer.rb
@@ -57,7 +57,7 @@ class CaesarImporter
   def transcription_create_attrs
     {
       id: subject_info[:id],
-      status: 0,
+      status: 3,
       text: data,
       metadata: subject_info[:metadata],
       group_id: subject_info[:metadata][:group_id] || 'default',


### PR DESCRIPTION
The original PR (#121) broke the build with the Caesar PR (#118) recently merging. Reversing the order should fix the tests.