### PR TITLE
update caesar importer to reflect status enum

### DIFF
--- a/app/services/caesar_importer.rb
+++ b/app/services/caesar_importer.rb
@@ -57,7 +57,7 @@ class CaesarImporter
   def transcription_create_attrs
     {
       id: subject_info[:id],
-      status: 0,
+      status: 'unseen',
       text: data,
       metadata: subject_info[:metadata],
       group_id: subject_info[:metadata][:group_id] || 'default',


### PR DESCRIPTION
The caesar importer code was out of sync with the updated status enum. Updated the `transcription_create_attrs` to fix that.