### PR TITLE
fix spelling of development env in gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,7 @@ group :test do
   gem 'pundit-matchers'
 end
 
-group :test, :devlopment, :staging do
+group :test, :development, :staging do
   gem 'pry-byebug'
   gem 'pry-rails'
 end


### PR DESCRIPTION
Fixing a very basic spelling mistake here that went uncaught by builds and such.