### PR TITLE
serialize transcription text only for show method

### DIFF
--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -87,7 +87,7 @@ class TranscriptionsController < ApplicationController
 
   def jsonapi_serializer_params
     {
-      serialize_text: url_options[:_recall][:action] == 'show'
+      serialize_text: action_name == 'show'
     }
   end
 end

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -87,7 +87,7 @@ class TranscriptionsController < ApplicationController
 
   def jsonapi_serializer_params
     {
-      is_collection: @transcriptions.respond_to?(:count)
+      serialize_text: url_options[:_recall][:action] == 'show'
     }
   end
 end

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -84,4 +84,10 @@ class TranscriptionsController < ApplicationController
   def update_attr_whitelist
     ["flagged", "text", "status"]
   end
+
+  def jsonapi_serializer_params
+    {
+      is_collection: @transcriptions.respond_to?(:count)
+    }
+  end
 end

--- a/app/serializers/transcription_serializer.rb
+++ b/app/serializers/transcription_serializer.rb
@@ -3,7 +3,7 @@ class TranscriptionSerializer
 
   attributes :workflow_id, :group_id, :status, :flagged, :updated_at, :updated_by
   attribute :text, if: proc { |_record, params|
-    params && params[:serialize_text] == true
+    params[:serialize_text] == true
   }
   belongs_to :workflow
 end

--- a/app/serializers/transcription_serializer.rb
+++ b/app/serializers/transcription_serializer.rb
@@ -1,6 +1,9 @@
 class TranscriptionSerializer
   include FastJsonapi::ObjectSerializer
 
-  attributes :workflow_id, :group_id, :text, :status, :flagged, :updated_at, :updated_by
+  attributes :workflow_id, :group_id, :status, :flagged, :updated_at, :updated_by
+  attribute :text, if: proc { |_record, params|
+    params && params[:is_collection] == false
+  }
   belongs_to :workflow
 end

--- a/app/serializers/transcription_serializer.rb
+++ b/app/serializers/transcription_serializer.rb
@@ -3,7 +3,7 @@ class TranscriptionSerializer
 
   attributes :workflow_id, :group_id, :status, :flagged, :updated_at, :updated_by
   attribute :text, if: proc { |_record, params|
-    params && params[:is_collection] == false
+    params && params[:serialize_text] == true
   }
   belongs_to :workflow
 end

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe TranscriptionsController, type: :controller do
           get :index
           expect(response).to have_http_status(:ok)
           expect(json_data.first).to have_type('transcription')
-          expect(json_data.first).to have_attributes(:text, :status, :flagged)
+          expect(json_data.first).to have_attributes(:status, :flagged)
           expect(json_data.first["id"]).to eql(transcription.id.to_s)
           expect(json_data.size).to eq(2)
         end

--- a/spec/serializers/transcription_serializer_spec.rb
+++ b/spec/serializers/transcription_serializer_spec.rb
@@ -2,23 +2,24 @@ RSpec.describe TranscriptionSerializer, type: :serializer do
   let(:transcription) { build(:transcription) }
 
   let(:serializer) { described_class.new(transcription) }
-  let(:serialized_data) { serializer.to_hash[:data][:attributes] }
+  let(:data) { serializer.to_hash[:data][:attributes] }
 
-  let(:collection_serializer) {
-    described_class.new(transcription, { params: { is_collection: true }})
+  let(:serializer_include_text) {
+    described_class.new(transcription, { params: { serialize_text: true }})
   }
-  let(:serialized_collection) { collection_serializer.to_hash[:data][:attributes] }
+  let(:data_with_text) { serializer_include_text.to_hash[:data][:attributes] }
 
   it 'serializes the expected attributes' do
-    expect(serialized_data).to have_key(:workflow_id)
-    expect(serialized_data).to have_key(:group_id)
-    expect(serialized_data).to have_key(:status)
-    expect(serialized_data).to have_key(:flagged)
-    expect(serialized_data).to have_key(:updated_at)
-    expect(serialized_data).to have_key(:updated_by)
+    expect(data_with_text).to have_key(:workflow_id)
+    expect(data_with_text).to have_key(:group_id)
+    expect(data_with_text).to have_key(:status)
+    expect(data_with_text).to have_key(:flagged)
+    expect(data_with_text).to have_key(:updated_at)
+    expect(data_with_text).to have_key(:updated_by)
+    expect(data_with_text).to have_key(:text)
   end
 
-  it 'doesnt serialize text when is_collection param is true' do
-    expect(serialized_collection).not_to have_key(:text)
+  it 'doesnt serialize text when serialize_text is not set' do
+    expect(data).not_to have_key(:text)
   end
 end

--- a/spec/serializers/transcription_serializer_spec.rb
+++ b/spec/serializers/transcription_serializer_spec.rb
@@ -1,15 +1,24 @@
 RSpec.describe TranscriptionSerializer, type: :serializer do
   let(:transcription) { build(:transcription) }
+
   let(:serializer) { described_class.new(transcription) }
   let(:serialized_data) { serializer.to_hash[:data][:attributes] }
+
+  let(:collection_serializer) {
+    described_class.new(transcription, { params: { is_collection: true }})
+  }
+  let(:serialized_collection) { collection_serializer.to_hash[:data][:attributes] }
 
   it 'serializes the expected attributes' do
     expect(serialized_data).to have_key(:workflow_id)
     expect(serialized_data).to have_key(:group_id)
-    expect(serialized_data).to have_key(:text)
     expect(serialized_data).to have_key(:status)
     expect(serialized_data).to have_key(:flagged)
     expect(serialized_data).to have_key(:updated_at)
     expect(serialized_data).to have_key(:updated_by)
+  end
+
+  it 'doesnt serialize text when is_collection param is true' do
+    expect(serialized_collection).not_to have_key(:text)
   end
 end


### PR DESCRIPTION
Closes #70.

* pass param `is_collection` to `TranscriptionSerializer`
* if is collection, don't serialize `text` attribute