### PR TITLE
allow filtering by internal id

### DIFF
--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -78,7 +78,7 @@ class TranscriptionsController < ApplicationController
   end
 
   def allowed_filters
-    [:id, :workflow_id, :group_id, :flagged, :status]
+    [:id, :workflow_id, :group_id, :flagged, :status, :internal_id]
   end
 
   def update_attr_whitelist

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe TranscriptionsController, type: :controller do
   before { allow(controller).to receive(:current_user).and_return admin_user }
 
   describe '#index' do
-    let!(:transcription) { create(:transcription, status: 1) }
+    let!(:transcription) { create(:transcription, status: 1, internal_id: 11) }
     let!(:another_transcription) { create(:transcription, workflow: transcription.workflow, status: 0) }
     let!(:separate_transcription) { create(:transcription, group_id: "HONK1", flagged: true, status: 2) }
 
@@ -62,6 +62,12 @@ RSpec.describe TranscriptionsController, type: :controller do
         get :index, params: { filter: { flagged_true: 1 } }
         expect(json_data.size).to eq(1)
         expect(json_data.first).to have_id(separate_transcription.id.to_s)
+      end
+
+      it 'filters by internal id' do
+        get :index, params: { filter: { internal_id_eq: 11 } }
+        expect(json_data.size).to eq(1)
+        expect(json_data.first).to have_id(transcription.id.to_s)
       end
 
       describe 'filters by id' do


### PR DESCRIPTION
Closes #72 .
Add  `internal_id` to allowed filters on transcription.