### PR TITLE
serialize additional transcription attributes

### DIFF
--- a/app/serializers/transcription_serializer.rb
+++ b/app/serializers/transcription_serializer.rb
@@ -1,7 +1,7 @@
 class TranscriptionSerializer
   include FastJsonapi::ObjectSerializer
 
-  attributes :workflow_id, :group_id, :status, :flagged, :updated_at, :updated_by, :internal_id, :total_lines, :total_pages, :low_consensus_lines
+  attributes :workflow_id, :group_id, :status, :flagged, :updated_at, :updated_by, :internal_id, :total_lines, :total_pages, :low_consensus_lines, :parameters, :reducer
   attribute :text, if: proc { |_record, params|
     params[:serialize_text] == true
   }

--- a/spec/serializers/transcription_serializer_spec.rb
+++ b/spec/serializers/transcription_serializer_spec.rb
@@ -21,6 +21,8 @@ RSpec.describe TranscriptionSerializer, type: :serializer do
     expect(data_with_text).to have_key(:total_lines)
     expect(data_with_text).to have_key(:total_pages)
     expect(data_with_text).to have_key(:low_consensus_lines)
+    expect(data_with_text).to have_key(:reducer)
+    expect(data_with_text).to have_key(:parameters)
   end
 
   it 'doesnt serialize text when serialize_text is not set' do


### PR DESCRIPTION
Additional attributes to serialize for transcriptions, requested by front-end:
* `reducer`
* `parameters`