### PR TITLE
Export file formatting

### DIFF
--- a/app/services/data_exports/data_storage.rb
+++ b/app/services/data_exports/data_storage.rb
@@ -10,7 +10,7 @@ module DataExports
     def zip_transcription_files(transcription)
       if transcription.export_files.attached?
         Dir.mktmpdir do |directory_path|
-          transcription_folder = download_transcription_files(transcription, directory_path)
+          transcription_folder = download_transcription_files(transcription, directory_path, single_transcription_export: true)
           yield zip_files(directory_path, transcription_folder)
         end
       else
@@ -69,14 +69,14 @@ module DataExports
     # @param transcription [Transcription]: the transcription we want to retrieve files for
     # @param directory_path [String]: path within which we will create the transcription file folder
     # returns location of generated transcription folder
-    def download_transcription_files(transcription, directory_path)
+    def download_transcription_files(transcription, directory_path, single_transcription_export: false)
       transcription_folder = File.join(directory_path, "transcription_#{transcription.id}")
       FileUtils.mkdir_p(transcription_folder)
 
       metadata_file_regex = /^transcription_metadata_.*\.csv$/
       transcription.export_files.each do |storage_file|
         is_transcription_metadata_file = metadata_file_regex.match storage_file.filename.to_s
-        unless is_transcription_metadata_file
+        unless is_transcription_metadata_file && !single_transcription_export
           download_path = File.join(transcription_folder, storage_file.filename.to_s)
           file = File.open(download_path, 'w')
           file.write(storage_file.download)

--- a/spec/services/data_exports/transcription_file_generator_spec.rb
+++ b/spec/services/data_exports/transcription_file_generator_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe DataExports::TranscriptionFileGenerator do
       end
 
       it 'generates a file containing raw data' do
-        raw_data_file = files.detect { |f|
+        raw_data_file = files.detect do |f|
           basename = File.basename(f)
           /^raw_data_.*\.json$/.match(basename)
-        }
+        end
 
         expect(File).to exist(raw_data_file.path)
-        expect(eval(raw_data_file.read)).to eq(transcription.text)
+        expect(raw_data_file.read).to eq(transcription.text.to_json)
       end
 
       it 'generates a file containing consensus text' do
@@ -99,7 +99,10 @@ RSpec.describe DataExports::TranscriptionFileGenerator do
           'page number',
           'column',
           'number of transcribers',
-          'line coordinates'
+          'line start x',
+          'line end x',
+          'line start y',
+          'line end y'
         ])
       end
     end


### PR DESCRIPTION
Closes #158 .
Update formatting:
* make sure `\n` shows up as newline for .txt files
* make sure to generate valid json
* split "line coordinates" into 4 separate columns for transcription line metadata file

Also, fix issue where transcription metadata file was not being downloaded as part of the export for single transcription exports.