### PR TITLE
Model locking updates

### DIFF
--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -16,6 +16,7 @@ module ErrorExtender
     rescue_from TranscriptionsController::LockedByAnotherUserError, with: :render_jsonapi_not_authorized
     rescue_from TranscriptionsController::NoExportableTranscriptionsError, with: :render_jsonapi_not_found
     rescue_from DataExports::DataStorage::NoStoredFilesFoundError, with: :render_jsonapi_not_found
+    rescue_from ActiveRecord::StaleObjectError, with: :render_jsonapi_conflict
 
     # override JSONAPI::Errors method to include exception message
     def render_jsonapi_not_found(exception)
@@ -54,6 +55,11 @@ module ErrorExtender
   def render_jsonapi_not_authorized(exception)
     error = error_object(403, exception)
     render jsonapi_errors: [error], status: :forbidden
+  end
+
+  def render_jsonapi_conflict(exception)
+    error = error_object(409, exception)
+    render jsonapi_errors: [error], status: :conflict
   end
 
   def error_object(status, exception)

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -44,6 +44,7 @@ class TranscriptionsController < ApplicationController
       end
     end
 
+    response.last_modified = @transcription.updated_at
     render jsonapi: @transcription
   end
 

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -281,7 +281,7 @@ RSpec.describe TranscriptionsController, type: :controller do
         expect(response).to have_http_status(:bad_request)
       end
 
-      it 'has been updated since the "If-Unmodified-Since" date', :focus do
+      it 'has been updated since the "If-Unmodified-Since" date' do
         request.headers['If-Unmodified-Since'] = (DateTime.now - 1.hour).httpdate
         patch :update, params: update_params
         expect(response).to have_http_status(:conflict)

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -280,6 +280,12 @@ RSpec.describe TranscriptionsController, type: :controller do
         patch :update, params: update_params
         expect(response).to have_http_status(:bad_request)
       end
+
+      it 'has been updated since the "If-Unmodified-Since" date', :focus do
+        request.headers['If-Unmodified-Since'] = (DateTime.now - 1.hour).httpdate
+        patch :update, params: update_params
+        expect(response).to have_http_status(:conflict)
+      end
     end
 
     describe 'roles' do

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -356,14 +356,6 @@ RSpec.describe TranscriptionsController, type: :controller do
       end
     end
 
-    context 'when last modified date does not match' do
-      it 'throws an error' do
-        request.headers['If-Unmodified-Since'] = (transcription.updated_at - 1.hours).httpdate
-        patch :update, params: update_params
-        expect(response).to have_http_status(:error)
-      end
-    end
-
     context 'when transcription is locked' do
       context 'when updating user is different from locked by user' do
         let(:transcription) { create(:transcription, locked_by: 'kar-aniyuki', lock_timeout: (DateTime.now + 1.hours)) }


### PR DESCRIPTION
* add 'Last-Modified' header to transcription PATCH response
* catch and serialize `StaleObjectError`
* PR also auto-linted some things across the updated files