### PR TITLE
update transcription status from unseen to in progress in #show action

### DIFF
--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -17,6 +17,11 @@ class TranscriptionsController < ApplicationController
     @transcription = Transcription.find(params[:id])
     authorize @transcription
 
+    if @transcription.status == 'unseen'
+      @transcription.status = 'in_progress'
+      @transcription.save!
+    end
+
     if TranscriptionPolicy.new(current_user, @transcription).has_update_rights?
       @transcription.lock!(current_user)
     end

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -143,19 +143,34 @@ RSpec.describe TranscriptionsController, type: :controller do
   end
 
   describe '#show' do
-    let!(:transcription) { create(:transcription) }
+    let!(:transcription) { create(:transcription, status: 'unseen') }
     let(:user) { create(:user, :admin) }
 
     before do
       allow(controller).to receive(:current_user).and_return user
-      get :show, params: { id: transcription.id }
     end
 
     it 'serializes the updated_at date in the "Last-Modified" header' do
+      get :show, params: { id: transcription.id }
       expect(response.header['Last-Modified']).to eq(transcription.updated_at.httpdate)
     end
 
+    it 'updates status to \'in progress\' if status is \'unseen\'' do
+      get :show, params: { id: transcription.id }
+      expect(json_data['attributes']['status']).to eq('in_progress')
+    end
+
+    it 'does not change status when status is not \'unseen\'' do
+      approved_transcription = create(:transcription, status: 'approved')
+      get :show, params: { id: approved_transcription.id }
+      expect(json_data['attributes']['status']).to eq('approved')
+    end
+
     describe 'roles' do
+      before do
+        get :show, params: { id: transcription.id }
+      end
+
       context 'without any roles' do
         let(:user) { create(:user, roles: {}) }
         it 'returns a 403' do


### PR DESCRIPTION
When user views a transcription that has status of `unseen`, the status should change to `in_progress`.