### PR TITLE
only lock transcription if it's not already locked

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,7 +35,7 @@ pipeline {
     }
 
     stage('Deploy production to Kubernetes') {
-      when { branch 'master' }
+      when { tag 'production-release' }
       agent any
       steps {
         sh "sed 's/__IMAGE_TAG__/${GIT_COMMIT}/g' kubernetes/deployment-production.tmpl | kubectl --context azure apply --record -f -"

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -17,7 +17,8 @@ class TranscriptionsController < ApplicationController
     @transcription = Transcription.find(params[:id])
     authorize @transcription
 
-    if TranscriptionPolicy.new(current_user, @transcription).has_update_rights?
+    if TranscriptionPolicy.new(current_user, @transcription).has_update_rights? &&
+       !@transcription.locked?
       @transcription.lock!(current_user)
     end
 

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -17,8 +17,7 @@ class TranscriptionsController < ApplicationController
     @transcription = Transcription.find(params[:id])
     authorize @transcription
 
-    if TranscriptionPolicy.new(current_user, @transcription).has_update_rights? &&
-       !@transcription.locked?
+    if @transcription.unlocked? && transcription_policy.has_update_rights?
       @transcription.lock!(current_user)
     end
 
@@ -176,5 +175,9 @@ class TranscriptionsController < ApplicationController
     rescue StandardError
       raise ValidationError, "#{since}: the value supplied in 'If-Unmodified-Since' header cannot be processed. The 'If-Unmodified-Since' header must contain the resource's GET request 'Last-Modified' header value."
     end
+  end
+
+  def transcription_policy
+    @policy ||= TranscriptionPolicy.new(current_user, @transcription)
   end
 end

--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -42,6 +42,10 @@ class Transcription < ApplicationRecord
     lock_timeout && DateTime.now < lock_timeout
   end
 
+  def unlocked?
+    !locked?
+  end
+
   def locked_by_different_user?(current_user_login)
     locked? && current_user_login != locked_by
   end

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -204,14 +204,13 @@ RSpec.describe TranscriptionsController, type: :controller do
       end
 
       context 'as an editor' do
-        let(:user) do
-          editor_roles =
-            {
-              transcription.workflow.project.id => ['expert'],
-              locked_transcription.workflow.project.id => ['expert']
-            }
-          create(:user, roles: editor_roles)
+        let(:editor_roles) do
+          {
+            transcription.workflow.project.id => ['expert'],
+            locked_transcription.workflow.project.id => ['expert']
+          }
         end
+        let(:user) { create(:user, roles: editor_roles) }
 
         it_behaves_like 'lockable transcription'
       end

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -167,20 +167,7 @@ RSpec.describe TranscriptionsController, type: :controller do
     end
 
     describe 'roles' do
-      shared_examples 'lockable transcription' do
-        let(:locked_transcription) { create(:transcription, locked_by: 'kar-aniyuki', lock_timeout: (DateTime.now + 1.hours)) }
-
-        it 'locks the transcription if not already locked' do
-          get :show, params: { id: transcription.id }
-          expect(json_data['attributes']['locked_by']).to eq(user.login)
-        end
-
-        it 'does not lock the transcription if it is already locked' do
-          expect do
-            get :show, params: { id: transcription.id }
-          end.not_to change { locked_transcription.locked_by }
-        end
-      end
+      let(:locked_transcription) { create(:transcription, locked_by: 'kar-aniyuki', lock_timeout: (DateTime.now + 1.hours)) }
 
       context 'without any roles' do
         let(:user) { create(:user, roles: {}) }
@@ -200,7 +187,16 @@ RSpec.describe TranscriptionsController, type: :controller do
           expect(json_data).to have_id(transcription.id.to_s)
         end
 
-        it_behaves_like 'lockable transcription'
+        it 'locks the transcription if not already locked' do
+          get :show, params: { id: transcription.id }
+          expect(json_data['attributes']['locked_by']).to eq(user.login)
+        end
+
+        it 'does not lock the transcription if it is already locked' do
+          expect do
+            get :show, params: { id: transcription.id }
+          end.not_to(change { locked_transcription.locked_by })
+        end
       end
 
       context 'as an editor' do
@@ -212,7 +208,16 @@ RSpec.describe TranscriptionsController, type: :controller do
         end
         let(:user) { create(:user, roles: editor_roles) }
 
-        it_behaves_like 'lockable transcription'
+        it 'locks the transcription if not already locked' do
+          get :show, params: { id: transcription.id }
+          expect(json_data['attributes']['locked_by']).to eq(user.login)
+        end
+
+        it 'does not lock the transcription if it is already locked' do
+          expect do
+            get :show, params: { id: transcription.id }
+          end.not_to(change { locked_transcription.locked_by })
+        end
       end
 
       context 'as a viewer' do

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -176,8 +176,9 @@ RSpec.describe TranscriptionsController, type: :controller do
         end
 
         it 'does not lock the transcription if it is already locked' do
-          get :show, params: { id: locked_transcription.id }
-          expect(json_data['attributes']['locked_by']).to eq(locked_transcription.locked_by)
+          expect do
+            get :show, params: { id: transcription.id }
+          end.not_to change { locked_transcription.locked_by }
         end
       end
 
@@ -205,10 +206,10 @@ RSpec.describe TranscriptionsController, type: :controller do
       context 'as an editor' do
         let(:user) do
           editor_roles =
-          {
-            transcription.workflow.project.id => ['expert'],
-            locked_transcription.workflow.project.id => ['expert']
-          }
+            {
+              transcription.workflow.project.id => ['expert'],
+              locked_transcription.workflow.project.id => ['expert']
+            }
           create(:user, roles: editor_roles)
         end
 


### PR DESCRIPTION
When user with edit permission views a transcription, confirm that the transcription is not already locked before locking the transcription.