### PR TITLE
Downcase metadata keys before checking for them

### DIFF
--- a/app/services/caesar_importer.rb
+++ b/app/services/caesar_importer.rb
@@ -59,9 +59,9 @@ class CaesarImporter
       id: subject_info[:id],
       status: 'unseen',
       text: data,
-      metadata: subject_info[:metadata],
-      group_id: subject_info[:metadata][:group_id] || 'default',
-      internal_id: subject_info[:metadata][:internal_id] || subject_info[:id],
+      metadata: subject_metadata,
+      group_id: subject_metadata[:group_id] || 'default',
+      internal_id: subject_metadata[:internal_id] || subject_info[:id],
       low_consensus_lines: data[:low_consensus_lines],
       total_lines: data[:transcribed_lines],
       reducer: data[:reducer],
@@ -82,5 +82,9 @@ class CaesarImporter
     unless reducible[:type] == 'Workflow'
       raise ReducibleError, 'Reducible must be a workflow'
     end
+  end
+
+  def subject_metadata
+    @metadata ||= subject_info[:metadata].transform_keys { |k| k.downcase }
   end
 end

--- a/spec/fixtures/caesar_payload.json
+++ b/spec/fixtures/caesar_payload.json
@@ -375,7 +375,9 @@
       "image4": "",
       "image5": "",
       "Addressee": "Oakes, Ziba B, 1806-1871",
-      "Description": "Wants runaway Moses sold"
+      "Description": "Wants runaway Moses sold",
+      "group_ID": "15584",
+      "internal_ID": "commonwealth:2z10z979z"
     },
     "created_at": "2017-09-06T15:10:52.697Z",
     "updated_at": "2017-11-09T19:27:49.622Z"

--- a/spec/services/caesar_importer_spec.rb
+++ b/spec/services/caesar_importer_spec.rb
@@ -121,6 +121,24 @@ RSpec.describe CaesarImporter, type: :service do
         t = Transcription.find(transcription_attrs[:id])
         transcription_attrs.each { |key, value| expect(t.send(key)).to eq(value) }
       end
+
+      describe 'mixed-case metadata fields' do
+        let(:new_metadata) { { 'group_ID' => "15584", 'internal_ID' => "commonwealth:2z10z979z"}.with_indifferent_access }
+        let(:new_subject) { { id: 999, metadata: new_metadata } }
+        let(:new_importer) { described_class.new(
+          id: 123,
+          reducible: {id: parsed_workflow[:id], type: 'Workflow'},
+          data: data,
+          subject: new_subject
+        )}
+
+        it 'correctly imports group and internal ids' do
+          new_importer.process
+          t = Transcription.find(transcription_attrs[:id])
+          expect(t.group_id).to eq("15584")
+          expect(t.internal_id).to eq("commonwealth:2z10z979z")
+        end
+      end
     end
 
     context 'when a transcription with the same id exists' do


### PR DESCRIPTION
Metadata keys like `group_ID` and `internal_ID` shouldn't fall back to defaults. The underscore and spelling still matter, but they can now be mixed-case.