### PR TITLE
Serve revision instead of commit_id

### DIFF
--- a/app/models/application_status.rb
+++ b/app/models/application_status.rb
@@ -1,7 +1,7 @@
 class ApplicationStatus
   def as_json(options = {})
     {
-      commit_id: Rails.application.commit_id
+      revision: Rails.application.revision
     }
   end
 end

--- a/app/models/application_status.rb
+++ b/app/models/application_status.rb
@@ -1,7 +1,7 @@
 class ApplicationStatus
   def as_json(options = {})
     {
-      revision: Rails.application.revision
+      revision: Rails.application.commit_id
     }
   end
 end

--- a/spec/controllers/status_controller_spec.rb
+++ b/spec/controllers/status_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe StatusController, type: :controller do
 
     it 'returns the commit id' do
       get :show
-      expect(response.body).to eq({:commit_id => 'example-id-3f8b092f285a'}.to_json)
+      expect(response.body).to eq({:revision => 'example-id-3f8b092f285a'}.to_json)
     end
   end
 end

--- a/spec/models/application_status_spec.rb
+++ b/spec/models/application_status_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe ApplicationStatus, type: :model do
   it "returns the commit id" do
     Rails.application.commit_id = 'example-id-3f8b092f285a'
-    expect(build(:application_status).as_json).to eq({:commit_id => 'example-id-3f8b092f285a'})
+    expect(build(:application_status).as_json).to eq({:revision => 'example-id-3f8b092f285a'})
   end
 end


### PR DESCRIPTION
Lots of other places in the repo this is referred to as commit_id, so I'll leave them all alone and just change what gets served up by the controller because that's what lita tries to parse.