### PR TITLE
Fix group transcription count

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -23,7 +23,7 @@ class Workflow < ApplicationRecord
       # construct the resulting data record results
       transcription_group_data[group_id] =
         {
-          updated_at: transcription.max_date,
+          updated_at: transcription.updated_at,
           updated_by: transcription.updated_by,
           transcription_count: group_transcription_count
         }
@@ -43,8 +43,7 @@ class Workflow < ApplicationRecord
   # we also sort the group transcriptions so the first record is the latest transcription
   def ordered_transcription_groups
     transcriptions
-      .select( "group_id, updated_by, max(updated_at) as max_date")
-      .group(:group_id, :updated_by)
-      .order("max_date DESC, group_id")
+      .select('id, group_id, updated_by, updated_at')
+      .order('updated_at DESC, group_id')
   end
 end

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -25,6 +25,14 @@ RSpec.describe Workflow, type: :model do
   let!(:transcription_three) do
     create(:transcription,
            workflow: workflow,
+           group_id: 'FIRST',
+           status: 1,
+           updated_at: '2019-1-09 00:00:00 UTC',
+           updated_by: 'Astrailis')
+  end
+  let!(:transcription_four) do
+    create(:transcription,
+           workflow: workflow,
            group_id: 'SECOND',
            status: 0,
            updated_by: 'Dove')
@@ -32,7 +40,7 @@ RSpec.describe Workflow, type: :model do
 
   describe '#transcription_group_data' do
     it 'counts transcriptions per group' do
-      expect(workflow.transcription_group_data['FIRST'][:transcription_count]).to eq(2)
+      expect(workflow.transcription_group_data['FIRST'][:transcription_count]).to eq(3)
     end
     it 'gets the date of the most recently updated transcription' do
       expect(workflow.transcription_group_data['FIRST'][:updated_at]).to eq('2019-12-16 00:00:00 UTC')

--- a/spec/models/workflow_spec.rb
+++ b/spec/models/workflow_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Workflow, type: :model do
 
   describe '#total_transcriptions' do
     it 'counts total transcriptions in workflow' do
-      expect(workflow.total_transcriptions).to eq(3)
+      expect(workflow.total_transcriptions).to eq(4)
     end
   end
 end


### PR DESCRIPTION
Closes issue #189 .

Using `group_by` in the following statement limited the transcription records retrieved to only one record per `group_id`/`updated_by`, which means we were not getting the right transcription count later in the code:
```ruby
transcriptions
      .select( "group_id, updated_by, max(updated_at) as max_date")
      .group(:group_id, :updated_by)
      .order("max_date DESC, group_id")
```

Update `ordered_transcription_groups` code to retrieve all transcriptions for the workflow.