### PR TITLE
Move rescue_from statements to TranscriptionsController

### DIFF
--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -12,9 +12,6 @@ module ErrorExtender
     rescue_from Panoptes::Client::AuthenticationExpired, with: :render_jsonapi_token_expired
     rescue_from Pundit::NotAuthorizedError, with: :render_jsonapi_not_authorized
     rescue_from ActionDispatch::Http::Parameters::ParseError, with: :render_jsonapi_bad_request
-    rescue_from TranscriptionsController::ValidationError, with: :render_jsonapi_bad_request
-    rescue_from TranscriptionsController::LockedByAnotherUserError, with: :render_jsonapi_not_authorized
-    rescue_from TranscriptionsController::NoExportableTranscriptionsError, with: :render_jsonapi_not_found
     rescue_from DataExports::DataStorage::NoStoredFilesFoundError, with: :render_jsonapi_not_found
     rescue_from ActiveRecord::StaleObjectError, with: :render_jsonapi_conflict
 

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -6,9 +6,9 @@ class TranscriptionsController < ApplicationController
   class ValidationError < StandardError; end
   class LockedByAnotherUserError < StandardError; end
 
-  rescue_from TranscriptionsController::ValidationError, with: :render_jsonapi_bad_request
-  rescue_from TranscriptionsController::LockedByAnotherUserError, with: :render_jsonapi_not_authorized
-  rescue_from TranscriptionsController::NoExportableTranscriptionsError, with: :render_jsonapi_not_found
+  rescue_from ValidationError, with: :render_jsonapi_bad_request
+  rescue_from LockedByAnotherUserError, with: :render_jsonapi_not_authorized
+  rescue_from NoExportableTranscriptionsError, with: :render_jsonapi_not_found
 
   before_action :status_filter_to_int, only: :index
 

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -6,6 +6,10 @@ class TranscriptionsController < ApplicationController
   class ValidationError < StandardError; end
   class LockedByAnotherUserError < StandardError; end
 
+  rescue_from TranscriptionsController::ValidationError, with: :render_jsonapi_bad_request
+  rescue_from TranscriptionsController::LockedByAnotherUserError, with: :render_jsonapi_not_authorized
+  rescue_from TranscriptionsController::NoExportableTranscriptionsError, with: :render_jsonapi_not_found
+
   before_action :status_filter_to_int, only: :index
 
   def index


### PR DESCRIPTION
Running into an issue of circular references when calling `rescue_from` in `ErrorExtender` on errors in `TranscriptionsController`. Moving these to `TranscriptionsController`. 

note: looks like the we are still able to call the render methods from the `ErrorExtender` from within the `TranscriptionsController`.