### PR TITLE
Check that `locked_by` is not null for `locked?` method

### DIFF
--- a/app/models/transcription.rb
+++ b/app/models/transcription.rb
@@ -39,7 +39,7 @@ class Transcription < ApplicationRecord
   end
 
   def locked?
-    lock_timeout && DateTime.now < lock_timeout
+    locked_by && lock_timeout && DateTime.now < lock_timeout
   end
 
   def unlocked?


### PR DESCRIPTION
In testing, we ran into a case where `locked_by` attribute on the transcription object was set to NULL but `lock_timeout` was still populated. We only want the lock to prevent an update if `locked_by` is populated. Update `locked?` method to reflect this.