### PR TITLE
send only 1% of import errors to sentry

### DIFF
--- a/app/controllers/caesar_controller.rb
+++ b/app/controllers/caesar_controller.rb
@@ -12,7 +12,10 @@ class CaesarController < ActionController::Base
       )
       importer.process
     rescue => exception
-      Raven.capture_exception(exception)
+      logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+      logger.tagged('DUP_ID') { logger.warn exception }
+
+      Raven.capture_exception(exception) if rand(100) == 1
       error = { status: '400', title: Rack::Utils::HTTP_STATUS_CODES[400] }
       render jsonapi_errors: [error], status: :bad_request
     else

--- a/app/controllers/caesar_controller.rb
+++ b/app/controllers/caesar_controller.rb
@@ -15,7 +15,7 @@ class CaesarController < ActionController::Base
       logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
       logger.tagged('DUP_ID') { logger.warn exception }
 
-      Raven.capture_exception(exception) if rand(100) == 1
+      Raven.capture_exception(exception) if report_error_with_rate_limit
       error = { status: '400', title: Rack::Utils::HTTP_STATUS_CODES[400] }
       render jsonapi_errors: [error], status: :bad_request
     else
@@ -23,4 +23,9 @@ class CaesarController < ActionController::Base
     end
   end
 
+  private
+
+  def report_error_with_rate_limit
+    rand(100) == 1
+  end
 end

--- a/spec/controllers/caesar_controller_spec.rb
+++ b/spec/controllers/caesar_controller_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe CaesarController, type: :controller do
     end
 
     it 'returns a 400 if there is an error' do
-      expect(Raven).to receive(:capture_exception)
       post :import, as: :json, body: {just: 'garbage'}.to_json
       expect(response).to have_http_status(:bad_request)
     end

--- a/spec/controllers/caesar_controller_spec.rb
+++ b/spec/controllers/caesar_controller_spec.rb
@@ -1,6 +1,8 @@
 RSpec.describe CaesarController, type: :controller do
 
   describe '#import' do
+    let(:tagged_logger_double) { double }
+
     it 'instantiates an importer and calls #process' do
       expect(CaesarImporter).to receive(:new).and_call_original
       expect_any_instance_of(CaesarImporter).to receive(:process)
@@ -18,8 +20,25 @@ RSpec.describe CaesarController, type: :controller do
     end
 
     it 'returns a 400 if there is an error' do
+      allow(controller).to receive(:report_error_with_rate_limit).and_return(true)
+      expect(Raven).to receive(:capture_exception)
+
       post :import, as: :json, body: {just: 'garbage'}.to_json
       expect(response).to have_http_status(:bad_request)
+    end
+
+    it 'logs error info if there is an error' do
+      expect(ActiveSupport::TaggedLogging)
+        .to receive(:new)
+        .with(Logger)
+        .and_return(tagged_logger_double)
+
+      allow(tagged_logger_double)
+        .to receive(:tagged)
+        .and_yield
+
+      expect(tagged_logger_double).to receive(:warn)
+      post :import, as: :json, body: {just: 'garbage'}.to_json
     end
   end
 end


### PR DESCRIPTION
Sentry is being sent too many of these duplicate id errors, such that we're approaching the quota too quickly. This PR is a temporary fix involving:
- sending all dup id errors to the rails logger
- only send 1% of all dup id errors over to sentry