### PR TITLE
account for encoding conversion error

### DIFF
--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -22,8 +22,8 @@ module ErrorExtender
     end
 
     # Overriding this JSONAPI::Errors method to add Sentry reporting
-    def render_jsonapi_internal_server_error(exception)
-      report_to_sentry(exception)
+    def render_jsonapi_internal_server_error(exception, use_sentry: true)
+      report_to_sentry(exception) if use_sentry
       super(exception)
     end
   end

--- a/app/controllers/concerns/error_extender.rb
+++ b/app/controllers/concerns/error_extender.rb
@@ -22,8 +22,8 @@ module ErrorExtender
     end
 
     # Overriding this JSONAPI::Errors method to add Sentry reporting
-    def render_jsonapi_internal_server_error(exception, use_sentry: true)
-      report_to_sentry(exception) if use_sentry
+    def render_jsonapi_internal_server_error(exception)
+      report_to_sentry(exception)
       super(exception)
     end
   end

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -9,6 +9,10 @@ class TranscriptionsController < ApplicationController
   rescue_from ValidationError, with: :render_jsonapi_bad_request
   rescue_from LockedByAnotherUserError, with: :render_jsonapi_not_authorized
   rescue_from NoExportableTranscriptionsError, with: :render_jsonapi_not_found
+  rescue_from Encoding::UndefinedConversionError do |exception|
+    # in this case, we already logged to sentry from within DataStorage class
+    render_jsonapi_internal_server_error(exception, use_sentry: false)
+  end
 
   before_action :status_filter_to_int, only: :index
 

--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -9,10 +9,7 @@ class TranscriptionsController < ApplicationController
   rescue_from ValidationError, with: :render_jsonapi_bad_request
   rescue_from LockedByAnotherUserError, with: :render_jsonapi_not_authorized
   rescue_from NoExportableTranscriptionsError, with: :render_jsonapi_not_found
-  rescue_from Encoding::UndefinedConversionError do |exception|
-    # in this case, we already logged to sentry from within DataStorage class
-    render_jsonapi_internal_server_error(exception, use_sentry: false)
-  end
+  rescue_from Encoding::UndefinedConversionError, with: :render_jsonapi_internal_server_error
 
   before_action :status_filter_to_int, only: :index
 

--- a/app/services/data_exports/data_storage.rb
+++ b/app/services/data_exports/data_storage.rb
@@ -12,7 +12,7 @@ module DataExports
       if transcription.export_files.attached?
         Dir.mktmpdir do |directory_path|
           transcription_folder = download_transcription_files(transcription, directory_path, single_transcription_export: true)
-          yield zip_files(directory_path, transcription_folder) if block_given?
+          yield zip_files(directory_path, transcription_folder)
         end
       else
         raise NoStoredFilesFoundError.new("No stored files found for transcription id '#{transcription.id}'")
@@ -93,12 +93,12 @@ module DataExports
       begin
         file.write(storage_file.download.force_encoding('UTF-8'))
       rescue Encoding::UndefinedConversionError => exception
-        file.close
         # build new exception with message including the problematic file
         message = exception.message + ". Filename: #{storage_file.filename}, Blob path: #{storage_file.key}, Blob id: #{storage_file.blob_id}"
         raise Encoding::UndefinedConversionError.new(message)
+      ensure
+        file.close
       end
-      file.close
     end
 
     # download workflow's transcription files from storage to disk

--- a/app/services/data_exports/data_storage.rb
+++ b/app/services/data_exports/data_storage.rb
@@ -96,8 +96,7 @@ module DataExports
         file.close
         # build new exception with message including the problematic file
         message = exception.message + ". Filename: #{storage_file.filename}, Blob path: #{storage_file.key}, Blob id: #{storage_file.blob_id}"
-        Raven.capture_exception(Encoding::UndefinedConversionError.new(message))
-        raise
+        raise Encoding::UndefinedConversionError.new(message)
       end
       file.close
     end

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -479,10 +479,9 @@ RSpec.describe TranscriptionsController, type: :controller do
         end
       end
 
-      it 'should render internal server error without logging to sentry for UndefinedConversionError' do
-        # we dont want to log to sentry at controller level because it's already done within DataStorage class
+      it 'should report internal server error to sentry in the case of a UndefinedConversionError' do
         allow(controller).to receive(:export) { raise Encoding::UndefinedConversionError }
-        expect(Raven).not_to receive(:capture_exception)
+        expect(Raven).to receive(:capture_exception)
         get :export, params: export_single_params
       end
 

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -479,6 +479,13 @@ RSpec.describe TranscriptionsController, type: :controller do
         end
       end
 
+      it 'should render internal server error without logging to sentry for UndefinedConversionError' do
+        # we dont want to log to sentry at controller level because it's already done within DataStorage class
+        allow(controller).to receive(:export) { raise Encoding::UndefinedConversionError }
+        expect(Raven).not_to receive(:capture_exception)
+        get :export, params: export_single_params
+      end
+
       describe 'roles' do
         context 'as a viewer' do
           let(:viewer) { create(:user, roles: { transcription.workflow.project.id => ['tester'] }) }

--- a/spec/services/data_exports/data_storage_spec.rb
+++ b/spec/services/data_exports/data_storage_spec.rb
@@ -25,14 +25,13 @@ RSpec.describe DataExports::DataStorage do
         end
       end
 
-      it "reports to sentry when there is an UndefinedConversionError" do
+      it "generates a custom message with file details when there is an UndefinedConversionError" do
         bad_encoding_file = instance_double(File)
-        allow(bad_encoding_file).to receive(:write) { raise Encoding::UndefinedConversionError }
+        allow(bad_encoding_file).to receive(:write) { raise Encoding::UndefinedConversionError.new('xCB from ASCII-8BIT to UTF-8') }
         allow(bad_encoding_file).to receive(:close)
         allow(File).to receive(:open) { bad_encoding_file }
 
-        expect(Raven).to receive(:capture_exception)
-        expect { data_storage.zip_transcription_files(transcription) }.to raise_error(Encoding::UndefinedConversionError)
+        expect { data_storage.zip_transcription_files(transcription) }.to raise_error(Encoding::UndefinedConversionError, /^xCB from ASCII-8BIT to UTF-8. Filename: transcription_file.txt, Blob path: [a-zA-Z0-9]*, Blob id: [0-9]*$/)
       end
     end
   end

--- a/spec/services/data_exports/data_storage_spec.rb
+++ b/spec/services/data_exports/data_storage_spec.rb
@@ -24,6 +24,16 @@ RSpec.describe DataExports::DataStorage do
           expect(File).to exist(zip_file)
         end
       end
+
+      it "reports to sentry when there is an UndefinedConversionError" do
+        bad_encoding_file = instance_double(File)
+        allow(bad_encoding_file).to receive(:write) { raise Encoding::UndefinedConversionError }
+        allow(bad_encoding_file).to receive(:close)
+        allow(File).to receive(:open) { bad_encoding_file }
+
+        expect(Raven).to receive(:capture_exception)
+        expect { data_storage.zip_transcription_files(transcription) }.to raise_error(Encoding::UndefinedConversionError)
+      end
     end
   end
 

--- a/spec/services/data_exports/data_storage_spec.rb
+++ b/spec/services/data_exports/data_storage_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe DataExports::DataStorage do
         allow(bad_encoding_file).to receive(:close)
         allow(File).to receive(:open) { bad_encoding_file }
 
-        expect { data_storage.zip_transcription_files(transcription) }.to raise_error(Encoding::UndefinedConversionError, /^xCB from ASCII-8BIT to UTF-8. Filename: transcription_file.txt, Blob path: [a-zA-Z0-9]*, Blob id: [0-9]*$/)
+        expect { data_storage.zip_transcription_files(transcription) {} }.to raise_error(Encoding::UndefinedConversionError, /^xCB from ASCII-8BIT to UTF-8. Filename: transcription_file.txt, Blob path: [a-zA-Z0-9]*, Blob id: [0-9]*$/)
       end
     end
   end


### PR DESCRIPTION
Encoding conversion error:
https://sentry.io/organizations/zooniverse-27/issues/1741500611/?project=1794129&query=is%3Aunresolved

This PR should fix the error from coming up again, but in case the error _does_ come up again, I have added additional logging to sentry (filename, blob path, blob id) to identify the exact file that is causing the issue.

Ideally, I would have used `ErrorExender`'s render jsonapi method from within `DataStorage`, but those methods are only accessible at the controller level, so I've had to write it so that we catch the exception in `DataStorage`, log to sentry with file info, raise it again and catch it again on the controller level.

Suggestions on a cleaner way to do this are welcome.