### PR TITLE
Catch and release RecordNotUnique errors

### DIFF
--- a/app/controllers/caesar_controller.rb
+++ b/app/controllers/caesar_controller.rb
@@ -11,21 +11,16 @@ class CaesarController < ActionController::Base
         subject: params[:subject]
       )
       importer.process
-    rescue => exception
+    rescue ActiveRecord::RecordNotUnique => exception
       logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
       logger.tagged('DUP_ID') { logger.warn exception }
-
-      Raven.capture_exception(exception) if report_error_with_rate_limit
+      head :no_content
+    rescue => exception
+      Raven.capture_exception(exception)
       error = { status: '400', title: Rack::Utils::HTTP_STATUS_CODES[400] }
       render jsonapi_errors: [error], status: :bad_request
     else
       head :no_content
     end
-  end
-
-  private
-
-  def report_error_with_rate_limit
-    rand(100) == 1
   end
 end


### PR DESCRIPTION
Like a little trout, too small to eat. We catch them, tag them, then swallow the exception and return a 204 to Caesar so nothing gets sent to Sentry but we've still got a way to keep tabs on them.