### PR TITLE
Increase RAM allocations

### DIFF
--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -19,10 +19,10 @@ spec:
           image: zooniverse/tove:__IMAGE_TAG__
           resources:
             requests:
-              memory: "200Mi"
+              memory: "400Mi"
               cpu: "10m"
             limits:
-              memory: "200Mi"
+              memory: "1000Mi"
               cpu: "500m"
           env:
             - name: RAILS_LOG_TO_STDOUT


### PR DESCRIPTION
App sits just under 200Mi idle and has been hitting the limit and causing (synchronous, in-memory) exports to fail. Boost it all a bit so we've got some room. Pushing this right after approving https://github.com/zooniverse/panoptes/pull/3601 so please lmk if these numbers push a bit too hard.