### PR TITLE
Add retrying to Azure downloads

### DIFF
--- a/app/lib/retryable.rb
+++ b/app/lib/retryable.rb
@@ -1,0 +1,25 @@
+module Retryable
+  SLEEP_INTERVAL = 0.4
+
+  def with_retries(retries: 3, rescue_class: )
+    tries = 0
+
+    begin
+      yield
+    rescue *rescue_class => e
+      tries += 1
+      if tries <= retries
+        sleep sleep_interval(tries)
+        retry
+      else
+        raise
+      end
+    end
+  end
+
+  private
+
+  def sleep_interval(tries)
+    (SLEEP_INTERVAL + rand(0.0..1.0)) * tries
+  end
+end

--- a/config/initializers/faraday.rb
+++ b/config/initializers/faraday.rb
@@ -1,0 +1,6 @@
+require 'faraday'
+
+# Sets a 5 second default timeout for read & write requests
+# Faraday is used under the hood by ActiveStorage, and therefore Azure Blob Storage
+Faraday.default_connection_options.request.open_timeout = 5
+Faraday.default_connection_options.request.timeout = 5

--- a/spec/lib/retryable_spec.rb
+++ b/spec/lib/retryable_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+require 'retryable'
+
+RSpec.describe Retryable do
+  class DummyClass
+    def process
+      with_retries(
+        rescue_class: [Faraday::TimeoutError, Errno::ECONNREFUSED]
+      ) { self.call_me_maybe }
+    end
+
+    # Can't raise the exception directly or it won't retry
+    def call_me_maybe
+      return "success"
+    end
+  end
+
+  let(:dummy_class) { DummyClass.new }
+
+  before(:each) do
+    # No retry timing randomness
+    allow_any_instance_of(Retryable).to receive(:sleep_interval).and_return(0)
+    dummy_class.extend(Retryable)
+  end
+
+  it 'tries 4 times, then re-raises the error' do
+    expect(dummy_class).to receive(:call_me_maybe).exactly(4).times.and_raise(Faraday::TimeoutError)
+    expect {
+      expect(dummy_class.process)
+    }.to raise_error(Faraday::TimeoutError)
+  end
+
+  it 'retries once then succeeds' do
+    expect(dummy_class).to receive(:call_me_maybe).once.and_raise(Errno::ECONNREFUSED)
+    expect(dummy_class).to receive(:call_me_maybe).once.and_return("success")
+    expect(dummy_class.process).to eq("success")
+  end
+end

--- a/spec/lib/retryable_spec.rb
+++ b/spec/lib/retryable_spec.rb
@@ -18,8 +18,9 @@ RSpec.describe Retryable do
   let(:dummy_class) { DummyClass.new }
 
   before(:each) do
-    # Calculate the sleep_interval with a constant rand() value
-    allow(Kernel).to receive(:rand).and_return(0.0)
+    # No waiting for the interval, no retry timing randomness
+    stub_const("Retryable::SLEEP_INTERVAL", 0.0)
+    allow_any_instance_of(Object).to receive(:rand).and_return(0.0)
     dummy_class.extend(Retryable)
   end
 

--- a/spec/lib/retryable_spec.rb
+++ b/spec/lib/retryable_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Retryable do
   let(:dummy_class) { DummyClass.new }
 
   before(:each) do
-    # No retry timing randomness
-    allow_any_instance_of(Retryable).to receive(:sleep_interval).and_return(0)
+    # Calculate the sleep_interval with a constant rand() value
+    allow(Kernel).to receive(:rand).and_return(0.0)
     dummy_class.extend(Retryable)
   end
 


### PR DESCRIPTION
Adds a Retryable module to mix in to classes that perform Azure downloads. This won't avoid the intermittent blob storage errors and will only increase the total request flight time. But better a few retries and a longer request than a failed download and no way to get the data out.

Faraday doesn't expose its retry middleware, nor does ActiveStorage expose the Azure storage retrying mechanics, so here you go. This is tested as best I could, since the methods that actually do the downloading are private and presently not unit tested themselves.

Also includes a setting of some sensible, five second default timeouts to a Faraday initializer. Hopefully the combination of the two will have this failing fast and then retrying and then succeeding. 