### PR TITLE
Add workaround to pull transcription data out manually

### DIFF
--- a/app/services/data_exports/data_storage.rb
+++ b/app/services/data_exports/data_storage.rb
@@ -40,9 +40,10 @@ module DataExports
 
     # Extremely hacky workaround for getting a group's worth of transcriptions out at a time.
     # Use this on the console to save a transcription group export locally, then kubectl cp them out of the pod directly.
-    # This also regens the files if the transcription is approved. Should take a while and might fail!
+    # This also (optionally) regens the files if the transcription is approved.
+    # Regenning files is heavy and could cause issues on large sets, be careful.
     # This'll go away very soon but will buy some time.
-    def save_transcription_files_locally(transcriptions)
+    def save_transcription_files_locally(transcriptions, regen: false)
       group_id = transcriptions.first.group_id
       workflow_id = transcriptions.first.workflow_id
       directory_path = "/tmp/saved/"
@@ -51,7 +52,7 @@ module DataExports
       FileUtils.mkdir_p(group_folder)
 
       transcriptions.each do |transcription|
-        transcription.upload_files_to_storage if transcription.approved?
+        transcription.upload_files_to_storage if regen && transcription.approved?
         download_transcription_files(transcription, group_folder) if transcription.export_files.attached?
       end
 

--- a/app/services/data_exports/data_storage.rb
+++ b/app/services/data_exports/data_storage.rb
@@ -38,6 +38,30 @@ module DataExports
       end
     end
 
+    # Extremely hacky workaround for getting a group's worth of transcriptions out at a time.
+    # Use this on the console to save a transcription group export locally, then kubectl cp them out of the pod directly.
+    # This also regens the files if the transcription is approved. Should take a while and might fail!
+    # This'll go away very soon but will buy some time.
+    def save_transcription_files_locally(transcriptions)
+      group_id = transcriptions.first.group_id
+      workflow_id = transcriptions.first.workflow_id
+      directory_path = "/tmp/saved/"
+
+      group_folder = File.join(directory_path, "wf_#{ workflow_id }_group_#{ group_id }")
+      FileUtils.mkdir_p(group_folder)
+
+      transcriptions.each do |transcription|
+        transcription.upload_files_to_storage if transcription.approved?
+        download_transcription_files(transcription, group_folder) if transcription.export_files.attached?
+      end
+
+      AggregateMetadataFileGenerator.generate_group_file(transcriptions, group_folder)
+
+      zip_file_path = File.join(directory_path, "wf_#{ workflow_id }_group_#{ group_id }_export.zip")
+      zip_generator = ZipFileGenerator.new(group_folder, zip_file_path)
+      zip_generator.write
+    end
+
     # Public : downloads all files for a given workflow
     # returns path to zip file
     def zip_workflow_files(workflow)

--- a/kubernetes/deployment-production.tmpl
+++ b/kubernetes/deployment-production.tmpl
@@ -22,7 +22,7 @@ spec:
               memory: "400Mi"
               cpu: "10m"
             limits:
-              memory: "1000Mi"
+              memory: "2000Mi"
               cpu: "500m"
           env:
             - name: RAILS_LOG_TO_STDOUT

--- a/kubernetes/deployment-staging.tmpl
+++ b/kubernetes/deployment-staging.tmpl
@@ -22,7 +22,7 @@ spec:
               memory: "200Mi"
               cpu: "10m"
             limits:
-              memory: "200Mi"
+              memory: "600Mi"
               cpu: "500m"
           env:
             - name: RAILS_LOG_TO_STDOUT


### PR DESCRIPTION
OK so don't judge me on this, ok? This adds a function that dispenses with all the tmp dirs and cleaning up and just brute forces regeneration of files for approved transcriptions and then grabs them all again and then grabs them all _again_ I think  to generate the aggregate metadata file and then zip it all up and leave it on the pod for me to go kubectl cp out later. It's possible that the original Azure error(s) I was seeing will pop up again, but at least I'll be able to see progress and diagnose in real time.

This is a big lift and though I've already tried tested on staging, the memory limit was killing any chance of seeing it finish. I left the requests alone but bumped the limits significantly to compensate.

Tove's data export functionality needs to be pretty seriously optimized and possibly entirely backgrounded. In the meantime, this will hopefully at least allow for the building of the biggest exports so they can be handed over to project teams. 