### PR TITLE
Optimize exports: first pass

### DIFF
--- a/app/controllers/transcriptions_controller.rb
+++ b/app/controllers/transcriptions_controller.rb
@@ -83,7 +83,8 @@ class TranscriptionsController < ApplicationController
     workflow = Workflow.find(params[:workflow_id])
     authorize workflow
 
-    @transcriptions = Transcription.where(group_id: params[:group_id], workflow_id: params[:workflow_id])
+    # Load attached export files as an include with a single extra query
+    @transcriptions = Transcription.with_attached_export_files.where(group_id: params[:group_id], workflow_id: params[:workflow_id])
 
     if @transcriptions.empty?
       raise NoExportableTranscriptionsError, "No exportable transcriptions found for group id '#{params[:group_id]}'"

--- a/app/services/data_exports/aggregate_metadata_file_generator.rb
+++ b/app/services/data_exports/aggregate_metadata_file_generator.rb
@@ -9,20 +9,20 @@ module DataExports
       include Retryable
       # Public: add metadata csv file to group folder
       def generate_group_file(transcriptions, output_folder)
-        metadata_rows = compile_transcription_metadata(transcriptions)
+        metadata_rows = compile_transcription_metadata(transcriptions, output_folder)
         generate_csv(output_folder, metadata_rows)
       end
 
       # Public: add metadata csv file to workflow folder
       def generate_workflow_file(workflow, output_folder)
-        metadata_rows = compile_workflow_metadata(workflow)
+        metadata_rows = compile_workflow_metadata(workflow, output_folder)
         generate_csv(output_folder, metadata_rows)
       end
 
       def generate_project_file(project, output_folder)
         metadata_rows = []
         project.workflows.each do |w|
-          metadata_rows += compile_workflow_metadata(w)
+          metadata_rows += compile_workflow_metadata(w, output_folder)
         end
 
         generate_csv(output_folder, metadata_rows)
@@ -35,38 +35,30 @@ module DataExports
       # csv file generator.
       # @param metadata_rows [Array]: collection of metadata rows for the current
       # group/workflow/project being processed
+      # @param output_folder [String]: the directory from which to read the metadata files
       # returns updated metadata_rows array
-      def compile_transcription_metadata(transcriptions)
+      def compile_transcription_metadata(transcriptions, group_folder)
         metadata_rows = []
-        metadata_file_regex = /^transcription_metadata_.*\.csv$/
-
         transcriptions.each do |transcription|
-          transcription.export_files.each do |storage_file|
-            is_transcription_metadata_file = metadata_file_regex.match storage_file.filename.to_s
-            if is_transcription_metadata_file
-              tmp_file = with_retries(
-                rescue_class: [Faraday::ConnectionFailed, Faraday::TimeoutError, Errno::ECONNREFUSED]
-              ) do
-                storage_file.download
-              end
-              rows = CSV.parse(tmp_file)
-              # add header if it's the first transcription being added
-              metadata_rows << rows[0] if metadata_rows.empty?
-              # add content regardless
-              metadata_rows << rows[1]
-            end
-          end
+          # Assumes that all transcription metadata files exist, since this step always comes after
+          # a full download and we don't want the db/storage costs of checking/downloading
+          metadata_filename = "#{ group_folder }/transcription_metadata_#{ transcription.id }.csv"
+          rows = CSV.read(metadata_filename)
+          # add header if it's the first transcription being added
+          metadata_rows << rows[0] if metadata_rows.empty?
+          # add content regardless
+          metadata_rows << rows[1]
         end
 
         metadata_rows
       end
 
-      def compile_workflow_metadata(workflow)
+      def compile_workflow_metadata(workflow, output_folder)
         metadata_rows = []
 
         workflow.transcription_group_data.each_key do |group_key|
           transcriptions = Transcription.where(group_id: group_key)
-          metadata_rows += compile_transcription_metadata(transcriptions)
+          metadata_rows += compile_transcription_metadata(transcriptions, output_folder)
         end
 
         metadata_rows

--- a/app/services/data_exports/data_storage.rb
+++ b/app/services/data_exports/data_storage.rb
@@ -28,11 +28,11 @@ module DataExports
         group_folder = File.join(directory_path, "group_#{transcriptions.first.group_id}")
         FileUtils.mkdir_p(group_folder)
 
-        AggregateMetadataFileGenerator.generate_group_file(transcriptions, group_folder)
-
         transcriptions.each do |transcription|
           download_transcription_files(transcription, group_folder) if transcription.export_files.attached?
         end
+
+        AggregateMetadataFileGenerator.generate_group_file(transcriptions, group_folder)
 
         yield zip_files(directory_path, group_folder)
       end
@@ -81,11 +81,11 @@ module DataExports
         project_folder = File.join(directory_path, "project_#{project.id}")
         FileUtils.mkdir_p(project_folder)
 
-        AggregateMetadataFileGenerator.generate_project_file(project, project_folder)
-
         project.workflows.each do |w|
           download_workflow_files(w, project_folder)
         end
+
+        AggregateMetadataFileGenerator.generate_project_file(project, project_folder)
 
         yield zip_files(directory_path, project_folder)
       end
@@ -103,10 +103,7 @@ module DataExports
 
       metadata_file_regex = /^transcription_metadata_.*\.csv$/
       transcription.export_files.each do |storage_file|
-        is_transcription_metadata_file = metadata_file_regex.match storage_file.filename.to_s
-        unless is_transcription_metadata_file && !single_transcription_export
-          download_file_from_storage(storage_file, transcription_folder)
-        end
+        download_file_from_storage(storage_file, transcription_folder)
       end
 
       transcription_folder

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -107,6 +107,7 @@ RSpec.describe ProjectsController, type: :controller do
 
     before do
       transcription.export_files.attach(blank_file_blob)
+      allow(DataExports::AggregateMetadataFileGenerator).to receive(:generate_project_file).and_return(true)
     end
 
     it 'returns successfully' do

--- a/spec/controllers/transcriptions_controller_spec.rb
+++ b/spec/controllers/transcriptions_controller_spec.rb
@@ -509,6 +509,7 @@ RSpec.describe TranscriptionsController, type: :controller do
     end
 
     describe '#export_group' do
+      before { allow(DataExports::AggregateMetadataFileGenerator).to receive(:generate_group_file).and_return(true) }
       # TO DO: create example for no trans in group
       context 'when group contains at least one transcription' do
         it 'returns successfully with content-type of application/zip' do

--- a/spec/controllers/workflows_controller_spec.rb
+++ b/spec/controllers/workflows_controller_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe WorkflowsController, type: :controller do
 
     before do
       transcription.export_files.attach(blank_file_blob)
+      allow(DataExports::AggregateMetadataFileGenerator).to receive(:generate_workflow_file).and_return(true)
     end
 
     it 'returns successfully' do

--- a/spec/services/data_exports/aggregate_metadata_file_generator_spec.rb
+++ b/spec/services/data_exports/aggregate_metadata_file_generator_spec.rb
@@ -13,6 +13,15 @@ RSpec.describe DataExports::AggregateMetadataFileGenerator do
   before(:each) do
     transcription.export_files.attach(transcription_metadata_blob)
     another_transcription.export_files.attach(transcription_metadata_blob)
+
+    # Create transcription metadata files that exist during an export
+    File.open("#{ parent_dir }/transcription_metadata_#{ transcription.id }.csv", 'w') do |f|
+      f.puts transcription.export_files.first.download
+    end
+
+    File.open("#{ parent_dir }/transcription_metadata_#{ another_transcription.id }.csv", 'w') do |f|
+      f.puts another_transcription.export_files.first.download
+    end
   end
 
   describe '#generate_group_file' do

--- a/spec/services/data_exports/data_storage_spec.rb
+++ b/spec/services/data_exports/data_storage_spec.rb
@@ -39,6 +39,7 @@ RSpec.describe DataExports::DataStorage do
   describe '#zip_group_files' do
     before(:each) do
       transcription.export_files.attach(blank_file_blob)
+      allow(DataExports::AggregateMetadataFileGenerator).to receive(:generate_group_file).and_return(true)
     end
 
     it "produces a zip file named export.zip" do
@@ -53,6 +54,7 @@ RSpec.describe DataExports::DataStorage do
   describe '#zip_workflow_files' do
     before(:each) do
       transcription.export_files.attach(blank_file_blob)
+      allow(DataExports::AggregateMetadataFileGenerator).to receive(:generate_workflow_file).and_return(true)
     end
 
     it "produces a zip file named export.zip" do
@@ -67,6 +69,7 @@ RSpec.describe DataExports::DataStorage do
   describe '#zip_project_files' do
     before(:each) do
       transcription.export_files.attach(blank_file_blob)
+      allow(DataExports::AggregateMetadataFileGenerator).to receive(:generate_project_file).and_return(true)
     end
 
     it "produces a zip file named export.zip" do


### PR DESCRIPTION
This is a first, basic pass at optimizing transcription exports in the hope that we can pull even the biggest workflows in under the 180s timeout. To that end:

First, use .with_attached_export_files to preload the Active Storage relations in a single DB call. This reduces the huge overhead of checking Active Storage (db) and checking Azure for the files for each transcription to a single pull of the transcriptions and a single double pull of ActiveStorage Attachments & Blobs.

Then, tuned some services to remove several instances of iteration through all a transcription's files just to determine which one is for metadata. Previously, this meant avoiding downloading the metadata file in `DataStorage# download_transcription_files` by repulling from the database, redownloading from Azure, and regex matching against the filename to find the metadata file. Then, this was repeated in the AggregateMetadataFileGenerator _only_ download that file  to concatenate to the group/project/workflow file. 

Instead, now we just download the metadata file along with all the other attached files. This leaves it on disk and allows the AggregateMetadataFileGenerator to use the path and id to build the expected file path and use it without needing to talk to the db or Azure again at all. This will mean that these individual transcription metadata files will be included in respective transcription folders, which seems fine to me but can be deleted at point of zipping them if necessary. 

Also moved all the calls to create those aggregate metadata files after the downloads, since those files are required. Needed to massage the specs a little bit too to avoid the files being missing in isolated tests.