### PR TITLE
GHA Deploy & Migrate 2

### DIFF
--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "Job Description:"
           kubectl describe job/$JOB_NAME
           echo "Pod Logs:"
-          kubectl logs $(kc get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
+          kubectl logs $(kubectl get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
       # - name: Clean up job if successful
       #   if: always()

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -1,6 +1,7 @@
 name: Run Database Migration (Staging)
 
 on:
+  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -40,8 +40,10 @@ jobs:
       - name: Log output
         if: always()
         run: |
+          echo "Job Description:"
           kubectl describe job/$JOB_NAME
-          kubectl logs --selector=job-name=$JOB_NAME
+          echo "Pod Logs:"
+          kc logs $(kc get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
       # - name: Clean up job if successful
       #   if: always()

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -43,12 +43,12 @@ jobs:
           kubectl describe job/$JOB_NAME
           kubectl logs --selector=job-name=$JOB_NAME
 
-      - name: Clean up job if successful
-        if: always()
-        run: |
-          if [ $JOB_EXIT_CODE -eq 0 ]; then
-            kubectl delete job $JOB_NAME
-          fi
+      # - name: Clean up job if successful
+      #   if: always()
+      #   run: |
+      #     if [ $JOB_EXIT_CODE -eq 0 ]; then
+      #       kubectl delete job $JOB_NAME
+      #     fi
 
       - name: Slack notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -45,12 +45,12 @@ jobs:
           echo "Pod Logs:"
           kubectl logs $(kubectl get pods --selector=job-name=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
-      # - name: Clean up job if successful
-      #   if: always()
-      #   run: |
-      #     if [ $JOB_EXIT_CODE -eq 0 ]; then
-      #       kubectl delete job $JOB_NAME
-      #     fi
+      - name: Clean up job if successful
+        if: always()
+        run: |
+          if [ $JOB_EXIT_CODE -eq 0 ]; then
+            kubectl delete job $JOB_NAME
+          fi
 
       - name: Slack notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -30,8 +30,8 @@ jobs:
 
       - name: Wait for completion or failure
         run: |
-          kubectl wait --for=condition=complete job/$JOB_NAME & completion_pid=$!
-          kubectl wait --for=condition=failed job/$JOB_NAME && exit 1 & failure_pid=$!
+          kubectl wait --for=condition=complete --timeout=86400s job/$JOB_NAME & completion_pid=$!
+          kubectl wait --for=condition=failed --timeout=86400s job/$JOB_NAME && exit 1 & failure_pid=$!
           wait -n $completion_pid $failure_pid
           exit_code=$?
           echo "JOB_EXIT_CODE=$exit_code" >> $GITHUB_ENV

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "Job Description:"
           kubectl describe job/$JOB_NAME
           echo "Pod Logs:"
-          kc logs $(kc get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
+          kubectl logs $(kc get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
       # - name: Clean up job if successful
       #   if: always()

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -1,7 +1,6 @@
 name: Run DB Migration (Staging)
 
 on:
-  pull_request:
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -1,4 +1,4 @@
-name: Run Database Migration (Staging)
+name: Run DB Migration (Staging)
 
 on:
   pull_request:

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -43,7 +43,7 @@ jobs:
           echo "Job Description:"
           kubectl describe job/$JOB_NAME
           echo "Pod Logs:"
-          kubectl logs $(kubectl get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
+          kubectl logs $(kubectl get pods --selector=job-name=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
       # - name: Clean up job if successful
       #   if: always()

--- a/.github/workflows/db_migration_staging.yaml
+++ b/.github/workflows/db_migration_staging.yaml
@@ -1,0 +1,94 @@
+name: Run Database Migration (Staging)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  db_migration_staging:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set the target AKS cluster
+        uses: Azure/aks-set-context@v1
+        with:
+          creds: '${{ secrets.AZURE_AKS }}'
+          cluster-name: microservices
+          resource-group: kubernetes
+
+      - name: Set environment variables
+        run: |
+          echo "DEPLOYED_IMAGE_TAG=$(kubectl get deployment tove-staging-app -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d':' -f 2)" >> $GITHUB_ENV
+          echo "JOB_NAME=tove-db-migration-staging-${{ github.run_number }}" >> $GITHUB_ENV
+
+      - name: Modify & apply template
+        run: |
+          sed "s/__IMAGE_TAG__/$DEPLOYED_IMAGE_TAG/g" ./kubernetes/db-migrate-staging.tmpl \
+            | sed "s/__JOB_NAME__/$JOB_NAME/g" \
+            | kubectl apply -f -
+
+      - name: Wait for completion or failure
+        run: |
+          kubectl wait --for=condition=complete job/$JOB_NAME & completion_pid=$!
+          kubectl wait --for=condition=failed job/$JOB_NAME && exit 1 & failure_pid=$!
+          wait -n $completion_pid $failure_pid
+          exit_code=$?
+          echo "JOB_EXIT_CODE=$exit_code" >> $GITHUB_ENV
+          exit $exit_code
+
+      - name: Log output
+        if: always()
+        run: |
+          kubectl describe job/$JOB_NAME
+          kubectl logs --selector=job-name=$JOB_NAME
+
+      - name: Clean up job if successful
+        if: always()
+        run: |
+          if [ $JOB_EXIT_CODE -eq 0 ]; then
+            kubectl delete job $JOB_NAME
+          fi
+
+      - name: Slack notification
+        uses: 8398a7/action-slack@v3
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        with:
+          fields: took
+          status: custom
+          custom_payload: |
+            {
+              "channel": "#ops",
+              "icon_emoji": ":octocat:",
+              "username": "DB Migrator",
+              "attachments": [{
+                "color": '${{ job.status }}' === 'success' ? 'good' : '${{ job.status }}' === 'failure' ? 'danger' : 'warning',
+                "mrkdwn_in": ["text"],
+                "author_name": "${{ github.actor }}",
+                "author_link": "https://github.com/${{ github.actor }}/",
+                "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
+                "title": "Tove Staging Database Migration complete",
+                "title_link": "https://github.com/zooniverse/tove/actions/${{ github.run_id }}",
+                "fields": [
+                    {
+                        "title": "Status",
+                        "value": '${{ job.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ job.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
+                        "short": true
+                    },
+                    {
+                        "title": "Triggered by",
+                        "value": "${{ github.event_name }}",
+                        "short": true
+                    },
+                    {
+                        "title": "Run Link",
+                        "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                ],
+                "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
+                "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
+                "footer_icon": "https://www.zooniverse.org/favicon.ico"
+              }]
+            }

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -20,6 +20,13 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Set the target AKS cluster
+      uses: Azure/aks-set-context@v1
+      with:
+        creds: '${{ secrets.AZURE_AKS }}'
+        cluster-name: microservices
+        resource-group: kubernetes
+
     - name: Get current deploy
       run: |
         echo "DEPLOYED_IMAGE_TAG=$(kubectl get deployment tove-staging-app -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d':' -f 2)" >> $GITHUB_ENV
@@ -48,13 +55,6 @@ jobs:
           ghcr.io/zooniverse/tove:latest
         cache-from: type=gha
         cache-to: type=gha,mode=max
-
-    - name: Set the target AKS cluster
-      uses: Azure/aks-set-context@v1
-      with:
-        creds: '${{ secrets.AZURE_AKS }}'
-        cluster-name: microservices
-        resource-group: kubernetes
 
     - name: Modify & apply template
       run: |

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -35,7 +35,7 @@ jobs:
       run: |
         if [ $DEPLOYED_IMAGE_TAG == ${{ github.sha }} ]; then
           echo "::warning::Deployed image matches latest commit, no new code to deploy. "
-          exit 0
+          exit 1
         fi
 
     - name: Create commit.txt

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -36,6 +36,8 @@ jobs:
         tags: |
           ghcr.io/zooniverse/tove:${{ github.sha }}
           ghcr.io/zooniverse/tove:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
     - name: Set the target AKS cluster
       uses: Azure/aks-set-context@v1

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -20,6 +20,17 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Get current deploy
+      run: |
+        echo "DEPLOYED_IMAGE_TAG=$(kubectl get deployment tove-staging-app -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d':' -f 2)" >> $GITHUB_ENV
+
+    - name: Check if deploy is necessary
+      run: |
+        if [ $DEPLOYED_IMAGE_TAG = ${{ github.sha }} ]; then
+          echo "::warning::Deployed image matches latest commit, no new code to deploy. "
+          exit 0
+        fi
+
     - name: Create commit.txt
       run: |
         echo ${{ github.sha }} > commit_id.txt

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -10,6 +10,9 @@ jobs:
   deploy-staging:
     runs-on: ubuntu-latest
     steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
     - name: Login to GitHub Container Registry
       uses: docker/login-action@v1
       with:

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -26,7 +26,7 @@ jobs:
 
     - name: Check if deploy is necessary
       run: |
-        if [ $DEPLOYED_IMAGE_TAG = ${{ github.sha }} ]; then
+        if [ $DEPLOYED_IMAGE_TAG == ${{ github.sha }} ]; then
           echo "::warning::Deployed image matches latest commit, no new code to deploy. "
           exit 0
         fi

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -20,9 +20,14 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Create commit.txt
+      run: |
+        echo ${{ github.sha }} > commit_id.txt
+
     - name: Build and push
       uses: docker/build-push-action@v2
       with:
+        context: .
         push: true
         tags: |
           ghcr.io/zooniverse/tove:${{ github.sha }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -20,10 +20,6 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Create commit.txt
-      run: |
-        echo ${{ github.sha }} > commit_id.txt
-
     - name: Build and push
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -25,7 +25,6 @@ jobs:
         echo ${{ github.sha }} > commit_id.txt
 
     - name: Set up Docker Buildx
-      id: buildx
       uses: docker/setup-buildx-action@v1
 
     - name: Build and push
@@ -36,8 +35,8 @@ jobs:
         tags: |
           ghcr.io/zooniverse/tove:${{ github.sha }}
           ghcr.io/zooniverse/tove:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Set the target AKS cluster
       uses: Azure/aks-set-context@v1

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -24,6 +24,10 @@ jobs:
       run: |
         echo ${{ github.sha }} > commit_id.txt
 
+    - name: Set up Docker Buildx
+      id: buildx
+      uses: docker/setup-buildx-action@v1
+
     - name: Build and push
       uses: docker/build-push-action@v2
       with:

--- a/.github/workflows/run_task_staging.yaml
+++ b/.github/workflows/run_task_staging.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "Job Description:"
           kubectl describe job/$JOB_NAME
           echo "Pod Logs:"
-          kubectl logs $(kc get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
+          kubectl logs $(kubectl get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
       # - name: Clean up job if successful
       #   if: always()

--- a/.github/workflows/run_task_staging.yaml
+++ b/.github/workflows/run_task_staging.yaml
@@ -46,8 +46,10 @@ jobs:
       - name: Log output
         if: always()
         run: |
+          echo "Job Description:"
           kubectl describe job/$JOB_NAME
-          kubectl logs --selector=job-name=$JOB_NAME
+          echo "Pod Logs:"
+          kc logs $(kc get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
       # - name: Clean up job if successful
       #   if: always()

--- a/.github/workflows/run_task_staging.yaml
+++ b/.github/workflows/run_task_staging.yaml
@@ -49,13 +49,13 @@ jobs:
           kubectl describe job/$JOB_NAME
           kubectl logs --selector=job-name=$JOB_NAME
 
-      - name: Clean up job if successful
-        if: always()
-        run: |
-          if [ $JOB_EXIT_CODE -eq 0 ]
-          then
-            kubectl delete job $JOB_NAME
-          fi
+      # - name: Clean up job if successful
+      #   if: always()
+      #   run: |
+      #     if [ $JOB_EXIT_CODE -eq 0 ]
+      #     then
+      #       kubectl delete job $JOB_NAME
+      #     fi
 
       - name: Slack notification
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/run_task_staging.yaml
+++ b/.github/workflows/run_task_staging.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "Job Description:"
           kubectl describe job/$JOB_NAME
           echo "Pod Logs:"
-          kubectl logs $(kubectl get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
+          kubectl logs $(kubectl get pods --selector=job-name=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
       # - name: Clean up job if successful
       #   if: always()

--- a/.github/workflows/run_task_staging.yaml
+++ b/.github/workflows/run_task_staging.yaml
@@ -36,8 +36,8 @@ jobs:
 
       - name: Wait for completion or failure
         run: |
-          kubectl wait --for=condition=complete job/$JOB_NAME & completion_pid=$!
-          kubectl wait --for=condition=failed job/$JOB_NAME && exit 1 & failure_pid=$!
+          kubectl wait --for=condition=complete --timeout=86400s job/$JOB_NAME & completion_pid=$!
+          kubectl wait --for=condition=failed --timeout=86400s job/$JOB_NAME && exit 1 & failure_pid=$!
           wait -n $completion_pid $failure_pid
           exit_code=$?
           echo "JOB_EXIT_CODE=$exit_code" >> $GITHUB_ENV

--- a/.github/workflows/run_task_staging.yaml
+++ b/.github/workflows/run_task_staging.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "Job Description:"
           kubectl describe job/$JOB_NAME
           echo "Pod Logs:"
-          kc logs $(kc get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
+          kubectl logs $(kc get pods --selector=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
       # - name: Clean up job if successful
       #   if: always()

--- a/.github/workflows/run_task_staging.yaml
+++ b/.github/workflows/run_task_staging.yaml
@@ -51,13 +51,13 @@ jobs:
           echo "Pod Logs:"
           kubectl logs $(kubectl get pods --selector=job-name=$JOB_NAME -o=jsonpath='{$.items[*].metadata.name}')
 
-      # - name: Clean up job if successful
-      #   if: always()
-      #   run: |
-      #     if [ $JOB_EXIT_CODE -eq 0 ]
-      #     then
-      #       kubectl delete job $JOB_NAME
-      #     fi
+      - name: Clean up job if successful
+        if: always()
+        run: |
+          if [ $JOB_EXIT_CODE -eq 0 ]
+          then
+            kubectl delete job $JOB_NAME
+          fi
 
       - name: Slack notification
         uses: 8398a7/action-slack@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN if [ "$RAILS_ENV" = "development" ]; then bundle install; else bundle instal
 
 ADD ./ /app
 
-RUN (cd /app && git log --format="%H" -n 1 > commit_id.txt)
 RUN (cd /app && mkdir -p tmp/pids)
 
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN if [ "$RAILS_ENV" = "development" ]; then bundle install; else bundle instal
 
 ADD ./ /app
 
+RUN (cd /app && git log --format="%H" -n 1 > commit_id.txt)
 RUN (cd /app && mkdir -p tmp/pids)
 
 EXPOSE 80

--- a/kubernetes/db-migrate-staging.tmpl
+++ b/kubernetes/db-migrate-staging.tmpl
@@ -1,0 +1,23 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: __JOB_NAME__
+spec:
+  template:
+    spec:
+      containers:
+      - name: tove-db-migrate-staging
+        image: zooniverse/tove:__IMAGE_TAG__
+        command: ["bundle",  "exec", "rails", "db:migrate"]
+        env:
+        - name: RAILS_LOG_TO_STDOUT
+          value: "true"
+        - name: RAILS_ENV
+          value: staging
+        - name: RAILS_MASTER_KEY
+          valueFrom:
+            secretKeyRef:
+              name: tove-staging
+              key: rails-master-key
+      restartPolicy: Never
+  backoffLimit: 1

--- a/kubernetes/db-migrate-staging.tmpl
+++ b/kubernetes/db-migrate-staging.tmpl
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: tove-db-migrate-staging
-        image: zooniverse/tove:__IMAGE_TAG__
+        image: ghcr.io/zooniverse/tove:__IMAGE_TAG__
         command: ["bundle",  "exec", "rails", "db:migrate"]
         env:
         - name: RAILS_LOG_TO_STDOUT

--- a/kubernetes/job-task-staging.tmpl
+++ b/kubernetes/job-task-staging.tmpl
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: tove-task-staging
-        image: zooniverse/tove:__IMAGE_TAG__
+        image: ghcr.io/zooniverse/tove:__IMAGE_TAG__
         command: ["bundle",  "exec", "rails", __TASK_NAME__]
         env:
         - name: RAILS_LOG_TO_STDOUT


### PR DESCRIPTION
### Staging Rake tasks
- [x] Add a TTL for the failed pods, just in case?

Executes via `workflow_dispatch` via the Actions tab, or locally with `gh workflow run 'Run Rake Task' --ref BRANCH_NAME -f rake_task=TASK_NAME`. `--ref` is optional, but helped a lot with testing for this PR since it can't run via an event.

### Staging Deploy:
- [x] Include checkout action so that it has a template to modify
- [x] Fix commit_id.txt generation
- [x] What if there are no changes? 
  * If the apply is successful BUT is a no-op because there's been no update to master, don't just fail, say something friendlier. 
  * This actually does the opposite and succeeds just fine with no indication it was a no-op. Is that better?
  * Successful no-ops look exactly like successful deploys. In a way, they are. 
  * Forcing a failure with `exit 1` and including a warning message on the run for right now. Can revisit making the slack message friendlier later.
- [x] Caching!
- [x] Buildx building

Executes via `workflow_dispatch` or a merge to master. 

### Staging Database Migration:
- [x] Use AKS cluster
- [x] Get currently-deployed image SHA via kubectl
- [x] Update db migration template with deployed image tag/sha
- [x] Apply template. 
- [x] Wait for completion and log output. **What should the timeout be here?** Someone should be watching, anyway.
- [x] Clean up successful job pods (keep failures for reference
- [x] Notify slack

Executes via `workflow_dispatch`, could add a merge to master for staging. 

**Production versions of above to come.**