### PR TITLE
Add new deploy and notification actions

### DIFF
--- a/.github/workflows/deploy_app.yaml
+++ b/.github/workflows/deploy_app.yaml
@@ -1,0 +1,74 @@
+name: Deploy App
+
+on:
+  # Run this workflow from other workflows
+  workflow_call:
+    inputs:
+      commit_id:
+        description: 'HEAD commit hash'
+        required: true
+        type: string
+      environment:
+        description: 'environment to affect'
+        required: true
+        type: string
+    secrets:
+      creds:
+        required: true
+
+jobs:
+  deploy_app:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v1
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set the target AKS cluster
+      uses: Azure/aks-set-context@v1
+      with:
+        creds: '${{ secrets.creds }}'
+        cluster-name: microservices
+        resource-group: kubernetes
+
+    - name: Get current deploy
+      run: |
+        echo "DEPLOYED_IMAGE_TAG=$(kubectl get deployment tove-${{ inputs.environment }}-app -o=jsonpath='{$.spec.template.spec.containers[:1].image}' | cut -d':' -f 2)" >> $GITHUB_ENV
+
+    - name: Check if deploy is necessary
+      run: |
+        if [ $DEPLOYED_IMAGE_TAG == ${{ inputs.commit_id }} ]; then
+          echo "::warning::Deployed image matches latest commit, no new code to deploy. "
+          exit 1
+        fi
+
+    - name: Create commit.txt
+      run: |
+        echo ${{ inputs.commit_id }} > commit_id.txt
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+      if: ${{ inputs.environment == 'staging' }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      if: ${{ inputs.environment == 'staging' }}
+      with:
+        context: .
+        push: true
+        tags: |
+          ghcr.io/zooniverse/tove:${{ inputs.commit_id }}
+          ghcr.io/zooniverse/tove:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Modify & apply template
+      run: |
+        sed "s/__IMAGE_TAG__/${{ inputs.commit_id }}/g" ./kubernetes/deployment-${{ inputs.environment }}.tmpl \
+          | kubectl apply -f -

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -1,0 +1,82 @@
+name: Send Slack notification
+
+on:
+  # Run this workflow from other workflows
+  workflow_call:
+    inputs:
+      commit_id:
+        description: 'HEAD commit hash'
+        required: true
+        type: string
+      job_name:
+        description: 'Job name to report on'
+        required: true
+        type: string
+      status:
+        description: 'Job status'
+        required: true
+        type: string
+      title_link:
+        description: 'Notification title link'
+        required: true
+        type: string
+    secrets:
+      slack_webhook_url:
+        required: true
+
+jobs:
+  slack_notification:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get associated PR info
+        run: |
+          response=$(curl https://api.github.com/repos/zooniverse/tove/commits/${{ inputs.commit_id }}/pulls)
+          echo "PR_URL=$(jq -r '.[].html_url' <<< "${response}")" >> $GITHUB_ENV
+          echo "PR_TITLE=$(jq -r '.[].title' <<< "${response}")" >> $GITHUB_ENV
+
+      - name: Slack notification
+        uses: 8398a7/action-slack@v3
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+        with:
+          job_name: ${{ inputs.job_name }}
+          fields: took
+          status: custom
+          custom_payload: |
+            {
+              "channel": "#deploys",
+              "icon_emoji": ":octocat:",
+              "username": "Deploy Action",
+              "attachments": [{
+                "color": '${{ inputs.status }}' === 'success' ? 'good' : '${{ inputs.status }}' === 'failure' ? 'danger' : 'warning',
+                "mrkdwn_in": ["text"],
+                "author_name": "${{ github.actor }}",
+                "author_link": "https://github.com/${{ github.actor }}/",
+                "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
+                "title": "Tove ${{ inputs.environment }} deploy complete",
+                "title_link": "${{ inputs.title_link }}",
+                "fields": [
+                    {
+                        "title": "Status",
+                        "value": '${{ inputs.status }}' === 'success' ? `:white_check_mark: Success in ${process.env.AS_TOOK}` : '${{ inputs.status }}' === 'failure' ? ':x: Failed' : ':warning: Warning',
+                        "short": true
+                    },
+                    {
+                        "title": "Triggered by",
+                        "value": "${{ github.event_name }}",
+                        "short": true
+                    },
+                    {
+                      "title": "Initiated by",
+                      "value": "<${{ env.PR_URL }}|${{ env.PR_TITLE }}>"
+                    },
+                    {
+                        "title": "Run Link",
+                        "value": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                ],
+                "thumb_url": "https://raw.githubusercontent.com/zooniverse/Brand/master/style%20guide/logos/zooniverse-emblem/zooniverse-logo-teal.png",
+                "footer": "<https://github.com/${{ github.repository }}|${{ github.repository }}> #${{ github.run_number }}",
+                "footer_icon": "https://www.zooniverse.org/favicon.ico"
+              }]
+            }


### PR DESCRIPTION
Adds the new standalone deploy and slack notification files. Should have gone in the last PR but `-a` doesn't add new files to git!