### PR TITLE
Send whole title to slack notifier

### DIFF
--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -24,7 +24,6 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Production / deploy_app
       status: ${{ needs.deploy_production.result }}
-      title: "Tove Production deploy complete"
       title_link: "https://alice.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -24,7 +24,7 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Production / deploy_app
       status: ${{ needs.deploy_production.result }}
-      title: "Tove Production deploy complete"
       title_link: "https://alice.zooniverse.org"
+      title: "Tove Production deploy complete"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -21,6 +21,7 @@ jobs:
     needs: deploy_production
     if: always()
     with:
+      environment: production
       commit_id: ${{ github.sha }}
       job_name: Deploy to Production / deploy_app
       status: ${{ needs.deploy_production.result }}

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -24,6 +24,6 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Production / deploy_app
       status: ${{ needs.deploy_production.result }}
-      link_text: "Tove Production deploy complete"
+      title_link: "https://alice.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -24,7 +24,7 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Production / deploy_app
       status: ${{ needs.deploy_production.result }}
-      environment: production
+      title: "Tove Production deploy complete"
       title_link: "https://alice.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -24,6 +24,7 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Production / deploy_app
       status: ${{ needs.deploy_production.result }}
+      title: "Tove Production deploy complete"
       title_link: "https://alice.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -24,7 +24,6 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Production / deploy_app
       status: ${{ needs.deploy_production.result }}
-      title_link: "https://alice.zooniverse.org"
-      title: "Tove Production deploy complete"
+      link_text: "Tove Production deploy complete"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -24,6 +24,7 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Staging / deploy_app
       status: ${{ needs.deploy_staging.result }}
+      title: "Tove Staging deploy complete"
       title_link: "https://alice.preview.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -21,6 +21,7 @@ jobs:
     needs: deploy_staging
     if: always()
     with:
+      environment: staging
       commit_id: ${{ github.sha }}
       job_name: Deploy to Staging / deploy_app
       status: ${{ needs.deploy_staging.result }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -24,6 +24,6 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Staging / deploy_app
       status: ${{ needs.deploy_staging.result }}
-      link_text: "Tove Staging deploy complete"
+      title_link: "https://alice.preview.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -24,7 +24,7 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Staging / deploy_app
       status: ${{ needs.deploy_staging.result }}
-      environment: staging
+      title: "Tove Staging deploy complete"
       title_link: "https://alice.preview.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -24,7 +24,6 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Staging / deploy_app
       status: ${{ needs.deploy_staging.result }}
-      title: "Tove Staging deploy complete"
       title_link: "https://alice.preview.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -24,7 +24,7 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Staging / deploy_app
       status: ${{ needs.deploy_staging.result }}
-      title: "Tove Staging deploy complete"
       title_link: "https://alice.preview.zooniverse.org"
+      title: "Tove Staging deploy complete"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -24,7 +24,6 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Staging / deploy_app
       status: ${{ needs.deploy_staging.result }}
-      title_link: "https://alice.preview.zooniverse.org"
-      title: "Tove Staging deploy complete"
+      link_text: "Tove Staging deploy complete"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -16,10 +16,6 @@ on:
         description: 'Job status'
         required: true
         type: string
-      title_link:
-        description: 'Notification title link'
-        required: true
-        type: string
       title:
         description: 'Notification title'
         required: true
@@ -57,8 +53,8 @@ jobs:
                 "author_name": "${{ github.actor }}",
                 "author_link": "https://github.com/${{ github.actor }}/",
                 "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-                "title": "${{ inputs.title }}",
-                "title_link": "${{ inputs.title_link }}",
+                "title": "${{ inputs.link_text }}",
+                "title_link": "https://zooniverse.org",
                 "fields": [
                     {
                         "title": "Status",

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -16,10 +16,6 @@ on:
         description: 'Job status'
         required: true
         type: string
-      title:
-        description: 'Title of message'
-        required: true
-        type: string
       title_link:
         description: 'Notification title link'
         required: true

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -4,6 +4,10 @@ on:
   # Run this workflow from other workflows
   workflow_call:
     inputs:
+      environment:
+        description: 'environment to report about'
+        required: true
+        type: string
       commit_id:
         description: 'HEAD commit hash'
         required: true
@@ -53,8 +57,8 @@ jobs:
                 "author_name": "${{ github.actor }}",
                 "author_link": "https://github.com/${{ github.actor }}/",
                 "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-                "title": "Tove Mystery deploy complete",
-                "title_link": "${{ inputs.tile_link }}",
+                "title": "Tove ${{ inputs.environment }} deploy complete",
+                "title_link": "${{ inputs.title_link }}",
                 "fields": [
                     {
                         "title": "Status",

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -16,12 +16,12 @@ on:
         description: 'Job status'
         required: true
         type: string
-      title:
-        description: 'Notification title'
-        required: true
-        type: string
       title_link:
         description: 'Notification title link'
+        required: true
+        type: string
+      title:
+        description: 'Notification title'
         required: true
         type: string
     secrets:

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -16,6 +16,10 @@ on:
         description: 'Job status'
         required: true
         type: string
+      title:
+        description: 'Notification title'
+        required: true
+        type: string
       title_link:
         description: 'Notification title link'
         required: true
@@ -53,7 +57,7 @@ jobs:
                 "author_name": "${{ github.actor }}",
                 "author_link": "https://github.com/${{ github.actor }}/",
                 "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-                "title": "Tove ? deploy complete",
+                "title": "${{ inputs.title }}",
                 "title_link": "${{ inputs.title_link }}",
                 "fields": [
                     {

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -53,7 +53,7 @@ jobs:
                 "author_name": "${{ github.actor }}",
                 "author_link": "https://github.com/${{ github.actor }}/",
                 "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-                "title": "${{ inputs.title }}",
+                "title": "Tove ? deploy complete",
                 "title_link": "${{ inputs.title_link }}",
                 "fields": [
                     {

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -16,8 +16,8 @@ on:
         description: 'Job status'
         required: true
         type: string
-      link_text:
-        description: 'Notification title'
+      title_link:
+        description: 'Notification title link'
         required: true
         type: string
     secrets:
@@ -53,8 +53,8 @@ jobs:
                 "author_name": "${{ github.actor }}",
                 "author_link": "https://github.com/${{ github.actor }}/",
                 "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-                "title": "${{ inputs.link_text }}",
-                "title_link": "https://zooniverse.org",
+                "title": "Tove Mystery deploy complete",
+                "title_link": "${{ inputs.tile_link }}",
                 "fields": [
                     {
                         "title": "Status",

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -16,8 +16,8 @@ on:
         description: 'Job status'
         required: true
         type: string
-      environment:
-        description: 'Environment to report about'
+      title:
+        description: 'Title of message'
         required: true
         type: string
       title_link:
@@ -57,7 +57,7 @@ jobs:
                 "author_name": "${{ github.actor }}",
                 "author_link": "https://github.com/${{ github.actor }}/",
                 "author_icon": "https://github.com/${{ github.actor }}.png?size=40",
-                "title": "Tove ${{ inputs.environment }} deploy complete",
+                "title": "${{ inputs.title }}",
                 "title_link": "${{ inputs.title_link }}",
                 "fields": [
                     {

--- a/.github/workflows/slack_notification.yaml
+++ b/.github/workflows/slack_notification.yaml
@@ -16,7 +16,7 @@ on:
         description: 'Job status'
         required: true
         type: string
-      title:
+      link_text:
         description: 'Notification title'
         required: true
         type: string


### PR DESCRIPTION
Lots of runner complaints about "Invalid input, environment is not defined in the referenced workflow" when I added the `environment` to the list of things passed to the slack notifier. Unclear on why, but genericizing the title beyond passing simply the env makes sense if I'm going to reuse this elsewhere eventually, anyway. So let's see if this helps.