### PR TITLE
Only send one notification, try to specify correct job name for timings

### DIFF
--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -38,21 +38,7 @@ jobs:
       commit_id: ${{ github.sha }}
       job_name: Deploy to Production / deploy_app
       status: ${{ needs.deploy_production.result }}
-      title: "Tove Production deploy complete"
-      title_link: "https://alice.zooniverse.org"
-    secrets:
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  migration_slack_notification:
-    name: Migration Slack notification
-    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
-    needs: db_migration_production
-    if: always()
-    with:
-      commit_id: ${{ github.sha }}
-      job_name: Production DB Migration / db_migration_production
-      status: ${{ needs.db_migration_production.result }}
-      title: "Tove Production database migration complete"
+      title: "Tove Production migration & deploy complete"
       title_link: "https://alice.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/deploy_staging.yaml
+++ b/.github/workflows/deploy_staging.yaml
@@ -45,23 +45,9 @@ jobs:
     if: always()
     with:
       commit_id: ${{ github.sha }}
-      job_name: Deploy to Staging / deploy_staging
+      job_name: Deploy to Staging / deploy_app
       status: ${{ needs.deploy_staging.result }}
-      title: "Tove Staging deploy complete"
-      title_link: "https://alice.preview.zooniverse.org"
-    secrets:
-      slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
-
-  migration_slack_notification:
-    name: Slack notification
-    uses: zooniverse/ci-cd/.github/workflows/slack_notification.yaml@main
-    needs: db_migration_staging
-    if: always()
-    with:
-      commit_id: ${{ github.sha }}
-      job_name: Staging DB Migration / db_migration_staging
-      status: ${{ needs.db_migration_staging.result }}
-      title: "Tove Staging database migration complete"
+      title: "Tove Staging migration & deploy complete"
       title_link: "https://alice.preview.zooniverse.org"
     secrets:
       slack_webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Running the deploy job requires the success of the migration job, two notifications is redundant.

Use the name of the shared workflow step to try to convince action-slack to get the correct job timings.