### PR TITLE
Update ruby 2.6 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM ruby:2.6-stretch
+FROM ruby:2.6
 WORKDIR /app
 ENV PORT=80
 ARG RAILS_ENV
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y git curl libpq-dev libjemalloc1 && \
+    apt-get install --no-install-recommends -y git curl libpq-dev libjemalloc2 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1
+ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 ADD ./Gemfile /app/
 ADD ./Gemfile.lock /app/


### PR DESCRIPTION
Stretch has been EOL'd, so use the base ruby 2.6 image instead. This uses bullseye as its own base image.

Also updates to jemalloc2 for performanace and because v1 has been removed.